### PR TITLE
Implement research GUI system

### DIFF
--- a/continent/src/main/java/me/continent/kingdom/Kingdom.java
+++ b/continent/src/main/java/me/continent/kingdom/Kingdom.java
@@ -16,6 +16,9 @@ public class Kingdom {
     private final Map<UUID, String> roles = new HashMap<>();
     private final Set<String> researchedNodes = new HashSet<>();
     private final Set<String> specialties = new HashSet<>();
+    private final Set<String> selectedResearchTrees = new HashSet<>();
+    private final Set<String> selectedT4Nodes = new HashSet<>();
+    private int researchSlots = 1;
 
     public Kingdom(String name, UUID leader, Village capital) {
         this.name = name;
@@ -102,5 +105,21 @@ public class Kingdom {
 
     public Set<String> getSpecialties() {
         return specialties;
+    }
+
+    public Set<String> getSelectedResearchTrees() {
+        return selectedResearchTrees;
+    }
+
+    public Set<String> getSelectedT4Nodes() {
+        return selectedT4Nodes;
+    }
+
+    public int getResearchSlots() {
+        return researchSlots;
+    }
+
+    public void setResearchSlots(int researchSlots) {
+        this.researchSlots = researchSlots;
     }
 }

--- a/continent/src/main/java/me/continent/kingdom/KingdomStorage.java
+++ b/continent/src/main/java/me/continent/kingdom/KingdomStorage.java
@@ -30,6 +30,9 @@ public class KingdomStorage {
         config.set("lastMaintenance", kingdom.getLastMaintenance());
         config.set("researched", new ArrayList<>(kingdom.getResearchedNodes()));
         config.set("specialties", new ArrayList<>(kingdom.getSpecialties()));
+        config.set("researchSlots", kingdom.getResearchSlots());
+        config.set("selectedTrees", new ArrayList<>(kingdom.getSelectedResearchTrees()));
+        config.set("selectedT4", new ArrayList<>(kingdom.getSelectedT4Nodes()));
 
         Map<String, String> roleMap = new HashMap<>();
         for (Map.Entry<UUID, String> e : kingdom.getRoles().entrySet()) {
@@ -60,6 +63,9 @@ public class KingdomStorage {
             long lastMaintenance = config.getLong("lastMaintenance", 0);
             List<String> researched = config.getStringList("researched");
             List<String> specialties = config.getStringList("specialties");
+            int researchSlots = config.getInt("researchSlots", 1);
+            List<String> selectedTrees = config.getStringList("selectedTrees");
+            List<String> selectedT4 = config.getStringList("selectedT4");
             Map<String, Object> rolesObj = config.getConfigurationSection("roles") != null ? config.getConfigurationSection("roles").getValues(false) : new HashMap<>();
 
             Kingdom kingdom = new Kingdom(name, leader, VillageManager.getByName(capitalName));
@@ -70,6 +76,9 @@ public class KingdomStorage {
             kingdom.setLastMaintenance(lastMaintenance);
             kingdom.getResearchedNodes().addAll(researched);
             kingdom.getSpecialties().addAll(specialties);
+            kingdom.setResearchSlots(researchSlots);
+            kingdom.getSelectedResearchTrees().addAll(selectedTrees);
+            kingdom.getSelectedT4Nodes().addAll(selectedT4);
             for (Map.Entry<String, Object> e : rolesObj.entrySet()) {
                 kingdom.getRoles().put(UUID.fromString(e.getKey()), Objects.toString(e.getValue(), ""));
             }

--- a/continent/src/main/java/me/continent/research/ResearchListener.java
+++ b/continent/src/main/java/me/continent/research/ResearchListener.java
@@ -6,11 +6,13 @@ import me.continent.village.Village;
 import me.continent.village.VillageManager;
 import org.bukkit.Material;
 import org.bukkit.block.Block;
+import org.bukkit.event.inventory.ClickType;
 import org.bukkit.event.inventory.InventoryClickEvent;
 import org.bukkit.event.player.PlayerInteractEvent;
 import org.bukkit.event.block.Action;
 import org.bukkit.inventory.Inventory;
 import org.bukkit.inventory.ItemStack;
+import org.bukkit.ChatColor;
 
 public class ResearchListener implements Listener {
     @EventHandler
@@ -19,16 +21,24 @@ public class ResearchListener implements Listener {
         if (inv.getHolder() instanceof ResearchManager.TreeHolder holder) {
             event.setCancelled(true);
             ItemStack item = event.getCurrentItem();
-            if (item == null) return;
-            String tree = item.getItemMeta() != null ? item.getItemMeta().getDisplayName() : null;
-            if (tree == null) return;
-            ResearchManager.openTreeMenu((org.bukkit.entity.Player) event.getWhoClicked(), tree);
+            if (item == null || item.getItemMeta() == null) return;
+            String name = ChatColor.stripColor(item.getItemMeta().getDisplayName());
+            String tree = name.contains(" ") ? name.substring(name.indexOf(' ') + 1) : name;
+            if (event.getClick() == ClickType.DOUBLE_CLICK) {
+                ResearchManager.toggleTreeSelect((org.bukkit.entity.Player) event.getWhoClicked(), tree);
+            } else {
+                ResearchManager.openNodeMenu((org.bukkit.entity.Player) event.getWhoClicked(), tree);
+            }
         } else if (inv.getHolder() instanceof ResearchManager.NodeHolder holder) {
             event.setCancelled(true);
+            int slot = event.getRawSlot();
+            if (slot == 53) {
+                ResearchManager.openTreeSelect((org.bukkit.entity.Player) event.getWhoClicked());
+                return;
+            }
             ItemStack item = event.getCurrentItem();
-            if (item == null) return;
-            String id = item.getItemMeta() != null ? item.getItemMeta().getDisplayName() : null;
-            if (id == null) return;
+            if (item == null || item.getItemMeta() == null) return;
+            String id = ChatColor.stripColor(item.getItemMeta().getDisplayName());
             ResearchNode node = ResearchManager.getAllNodes().stream()
                     .filter(n -> n.getId().equals(id))
                     .findFirst().orElse(null);
@@ -57,6 +67,6 @@ public class ResearchListener implements Listener {
         }
 
         event.setCancelled(true);
-        ResearchManager.openMenu(event.getPlayer());
+        ResearchManager.openTreeSelect(event.getPlayer());
     }
 }

--- a/continent/src/main/java/me/continent/research/ResearchManager.java
+++ b/continent/src/main/java/me/continent/research/ResearchManager.java
@@ -3,22 +3,37 @@ package me.continent.research;
 import me.continent.ContinentPlugin;
 import me.continent.kingdom.Kingdom;
 import me.continent.kingdom.KingdomManager;
+import me.continent.kingdom.KingdomStorage;
+import me.continent.village.Village;
+import me.continent.village.VillageManager;
 import org.bukkit.Bukkit;
 import org.bukkit.Material;
+import org.bukkit.boss.BarColor;
+import org.bukkit.boss.BarStyle;
+import org.bukkit.boss.BossBar;
 import org.bukkit.configuration.file.FileConfiguration;
 import org.bukkit.configuration.file.YamlConfiguration;
 import org.bukkit.entity.Player;
 import org.bukkit.inventory.Inventory;
+import org.bukkit.inventory.InventoryHolder;
+import org.bukkit.inventory.ItemFlag;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.meta.ItemMeta;
+import org.bukkit.enchantments.Enchantment;
 import org.bukkit.scheduler.BukkitRunnable;
 
 import java.io.File;
+import java.time.Duration;
 import java.util.*;
 
+/**
+ * Manages research data and GUI for kingdoms.
+ */
 public class ResearchManager {
     private static final Map<String, ResearchNode> nodes = new HashMap<>();
+    private static final Map<String, ResearchTask> tasks = new HashMap<>();
 
+    /** Load research node definitions from YAML. */
     public static void loadNodes(ContinentPlugin plugin) {
         File file = new File(plugin.getDataFolder(), "research_nodes.yml");
         if (!file.exists()) {
@@ -28,8 +43,7 @@ public class ResearchManager {
         for (String tree : config.getKeys(false)) {
             for (String tierKey : Objects.requireNonNull(config.getConfigurationSection(tree)).getKeys(false)) {
                 int tier = Integer.parseInt(tierKey.substring(1));
-                List<Map<?, ?>> list = config.getMapList(tree + "." + tierKey);
-                for (Map<?, ?> map : list) {
+                for (Map<?, ?> map : config.getMapList(tree + "." + tierKey)) {
                     String id = Objects.toString(map.get("id"));
                     String effect = Objects.toString(map.get("effect"));
                     String cost = Objects.toString(map.get("cost"));
@@ -47,64 +61,164 @@ public class ResearchManager {
         return nodes.values();
     }
 
-    public static void openMenu(Player player) {
+    // ------------------------------------------------------- GUI
+
+    /** Open tree selection GUI. */
+    public static void openTreeSelect(Player player) {
         Kingdom kingdom = getKingdom(player);
         if (kingdom == null) {
             player.sendMessage("§c소속된 국가가 없습니다.");
             return;
         }
-        Set<String> trees = new LinkedHashSet<>();
-        for (ResearchNode node : nodes.values()) {
-            trees.add(node.getTree());
-        }
-        int size = ((trees.size() - 1) / 9 + 1) * 9;
-        Inventory inv = Bukkit.createInventory(new TreeHolder(kingdom), size, "Research Trees");
+        Inventory inv = Bukkit.createInventory(new TreeHolder(kingdom), 9, "연구 트리 선택");
         TreeHolder holder = (TreeHolder) inv.getHolder();
         holder.setInventory(inv);
-        int slot = 0;
-        for (String tree : trees) {
-            ItemStack item = new ItemStack(Material.PAPER);
-            ItemMeta meta = item.getItemMeta();
-            meta.setDisplayName(tree);
-            item.setItemMeta(meta);
-            inv.setItem(slot++, item);
-        }
+
+        setTreeItem(inv, 1, "MILITARY", kingdom);
+        setTreeItem(inv, 2, "NAVAL", kingdom);
+        setTreeItem(inv, 4, "INFRA", kingdom);
+        setTreeItem(inv, 6, "CIVIL", kingdom);
+        setTreeItem(inv, 7, "INDUSTRY", kingdom);
+
         player.openInventory(inv);
     }
 
-    public static void openTreeMenu(Player player, String tree) {
+    /** Update or create a tree item based on selection state. */
+    private static void setTreeItem(Inventory inv, int slot, String tree, Kingdom k) {
+        boolean selected = k.getSelectedResearchTrees().contains(tree) || tree.equals("INFRA");
+        if (tree.equals("INFRA")) k.getSelectedResearchTrees().add("INFRA");
+        boolean disabled = !selected && k.getSelectedResearchTrees().size() >= k.getResearchSlots();
+        String prefix = selected ? "✅ " : disabled ? "⛔ " : "📂 ";
+
+        ItemStack item = new ItemStack(Material.PAPER);
+        ItemMeta meta = item.getItemMeta();
+        meta.setDisplayName(prefix + tree);
+        List<String> lore = new ArrayList<>();
+        if (tree.equals("INFRA")) {
+            lore.add("§7항상 선택됨");
+        } else if (disabled) {
+            lore.add("§7연구 슬롯 부족");
+        } else if (selected) {
+            lore.add("§7더블클릭으로 선택 해제");
+        } else {
+            lore.add("§7더블클릭으로 선택");
+        }
+        meta.setLore(lore);
+        item.setItemMeta(meta);
+        inv.setItem(slot, item);
+    }
+
+    /** Open detailed node GUI for the given tree. */
+    public static void openNodeMenu(Player player, String tree) {
         Kingdom kingdom = getKingdom(player);
         if (kingdom == null) {
             player.sendMessage("§c소속된 국가가 없습니다.");
             return;
         }
+        Inventory inv = Bukkit.createInventory(new NodeHolder(kingdom, tree), 54, tree + " 연구");
+        NodeHolder holder = (NodeHolder) inv.getHolder();
+        holder.setInventory(inv);
+
+        ItemStack info = new ItemStack(Material.PAPER);
+        ItemMeta m = info.getItemMeta();
+        m.setDisplayName(tree);
+        m.setLore(List.of("§7선택된 트리"));
+        info.setItemMeta(m);
+        inv.setItem(4, info);
+
         List<ResearchNode> list = nodes.values().stream()
                 .filter(n -> n.getTree().equalsIgnoreCase(tree))
                 .sorted(Comparator.comparingInt(ResearchNode::getTier))
                 .toList();
-        Inventory inv = Bukkit.createInventory(new NodeHolder(kingdom, tree), 54, tree + " Research");
-        NodeHolder holder = (NodeHolder) inv.getHolder();
-        holder.setInventory(inv);
-        int slot = 0;
         for (ResearchNode node : list) {
-            ItemStack item = new ItemStack(Material.BOOK);
-            ItemMeta meta = item.getItemMeta();
-            meta.setDisplayName(node.getId());
-            List<String> lore = new ArrayList<>();
-            lore.add("Tier " + node.getTier());
-            lore.add(node.getEffect());
-            lore.add("Cost: " + node.getCost());
-            lore.add("Time: " + node.getTime());
-            if (kingdom.getResearchedNodes().contains(node.getId())) {
-                lore.add("§a연구 완료");
-            }
-            meta.setLore(lore);
-            item.setItemMeta(meta);
-            inv.setItem(slot++, item);
+            int slot = getSlotForNode(node);
+            if (slot >= 0) inv.setItem(slot, createNodeItem(kingdom, node));
         }
+
+        ItemStack back = new ItemStack(Material.ARROW);
+        ItemMeta bm = back.getItemMeta();
+        bm.setDisplayName("§c돌아가기");
+        back.setItemMeta(bm);
+        inv.setItem(53, back);
+
         player.openInventory(inv);
     }
 
+    /** Determine slot index for node in GUI. */
+    private static int getSlotForNode(ResearchNode node) {
+        return switch (node.getTier()) {
+            case 1 -> node.getId().endsWith("1") ? 19 : 28;
+            case 2 -> node.getId().endsWith("1") ? 21 : 30;
+            case 3 -> node.getId().endsWith("1") ? 23 : 32;
+            case 4 -> {
+                List<ResearchNode> t4 = nodes.values().stream()
+                        .filter(n -> n.getTree().equals(node.getTree()) && n.getTier() == 4)
+                        .sorted(Comparator.comparing(ResearchNode::getId))
+                        .toList();
+                int idx = t4.indexOf(node);
+                yield 16 + idx * 9;
+            }
+            default -> -1;
+        };
+    }
+
+    /** Create node item with state-specific display. */
+    private static ItemStack createNodeItem(Kingdom k, ResearchNode node) {
+        ResearchState state = getState(k, node);
+        ItemStack item = switch (state) {
+            case LOCKED -> new ItemStack(Material.BARRIER);
+            case AVAILABLE, IN_PROGRESS -> new ItemStack(Material.BOOK);
+            case COMPLETED -> new ItemStack(Material.ENCHANTED_BOOK);
+        };
+        ItemMeta meta = item.getItemMeta();
+        String color = switch (state) {
+            case LOCKED -> "§7";
+            case AVAILABLE -> "§f";
+            case IN_PROGRESS -> "§e";
+            case COMPLETED -> "§a";
+        };
+        meta.setDisplayName(color + node.getId());
+        List<String> lore = new ArrayList<>();
+        lore.add("§7필요 골드: " + node.getCost());
+        lore.add("§7필요 시간: " + node.getTime());
+        String stateText = switch (state) {
+            case LOCKED -> "🔒 잠김";
+            case AVAILABLE -> "☑ 연구 가능";
+            case IN_PROGRESS -> "🕓 진행 중";
+            case COMPLETED -> "✅ 완료됨";
+        };
+        lore.add("§7상태: " + stateText);
+        lore.add("§8효과: " + node.getEffect());
+        meta.setLore(lore);
+        if (state == ResearchState.IN_PROGRESS || state == ResearchState.COMPLETED) {
+            meta.addEnchant(Enchantment.UNBREAKING, 1, true);
+            meta.addItemFlags(ItemFlag.HIDE_ENCHANTS);
+        }
+        item.setItemMeta(meta);
+        return item;
+    }
+
+    // ------------------------------------------------------- Actions
+
+    /** Toggle tree selection on double click. */
+    public static void toggleTreeSelect(Player player, String tree) {
+        Kingdom k = getKingdom(player);
+        if (k == null || tree.equals("INFRA")) return;
+        Set<String> set = k.getSelectedResearchTrees();
+        if (set.contains(tree)) {
+            set.remove(tree);
+        } else {
+            if (set.size() >= k.getResearchSlots()) {
+                player.sendMessage("§c연구 슬롯이 부족합니다.");
+                return;
+            }
+            set.add(tree);
+        }
+        KingdomStorage.save(k);
+        openTreeSelect(player);
+    }
+
+    /** Start research on a node if possible. */
     public static void startResearch(Player player, ResearchNode node) {
         Kingdom kingdom = getKingdom(player);
         if (kingdom == null) {
@@ -121,6 +235,14 @@ public class ResearchManager {
                 return;
             }
         }
+        if (node.getTier() == 4 && !kingdom.getSelectedT4Nodes().contains(node.getId())) {
+            if (kingdom.getSelectedT4Nodes().size() >= 2) {
+                player.sendMessage("§cT4 노드는 최대 두 개만 선택 가능합니다.");
+                return;
+            }
+            kingdom.getSelectedT4Nodes().add(node.getId());
+        }
+
         double cost = node.getGoldCost();
         if (kingdom.getTreasury() < cost) {
             player.sendMessage("§c국고가 부족합니다.");
@@ -128,50 +250,134 @@ public class ResearchManager {
         }
 
         kingdom.removeGold(cost);
-        me.continent.kingdom.KingdomStorage.save(kingdom);
+        KingdomStorage.save(kingdom);
 
         player.sendMessage("§a연구를 시작합니다: " + node.getId());
         player.sendMessage("§e연구 비용 " + cost + "G 차감");
-        new BukkitRunnable() {
-            @Override
-            public void run() {
-                kingdom.getResearchedNodes().add(node.getId());
-                player.sendMessage("§e연구 완료: " + node.getId());
-                me.continent.kingdom.KingdomStorage.save(kingdom);
-            }
-        }.runTaskLater(ContinentPlugin.getInstance(), 20L * 5); // 5초 테스트용
+
+        long duration = parseDuration(node.getTime());
+        ResearchTask task = new ResearchTask(kingdom, node, duration);
+        tasks.put(kingdom.getName() + ":" + node.getId(), task);
+        task.start();
+        openNodeMenu(player, node.getTree());
     }
 
+    /** Determine node state for the given kingdom. */
+    private static ResearchState getState(Kingdom k, ResearchNode node) {
+        if (k.getResearchedNodes().contains(node.getId())) return ResearchState.COMPLETED;
+        if (tasks.containsKey(k.getName() + ":" + node.getId())) return ResearchState.IN_PROGRESS;
+        for (String pre : node.getPrereq()) {
+            if (!k.getResearchedNodes().contains(pre)) return ResearchState.LOCKED;
+        }
+        if (node.getTier() == 4 && !k.getSelectedT4Nodes().contains(node.getId()) && k.getSelectedT4Nodes().size() >= 2) {
+            return ResearchState.LOCKED;
+        }
+        return ResearchState.AVAILABLE;
+    }
+
+    /** Parse duration string like "1시간30분" to ticks. */
+    private static long parseDuration(String time) {
+        int hours = 0;
+        int minutes = 0;
+        if (time.contains("시간")) {
+            try { hours = Integer.parseInt(time.split("시간")[0].trim()); } catch (Exception ignored) {}
+            time = time.substring(time.indexOf("시간") + 2);
+        }
+        if (time.contains("분")) {
+            try { minutes = Integer.parseInt(time.split("분")[0].trim()); } catch (Exception ignored) {}
+        }
+        Duration d = Duration.ofHours(hours).plusMinutes(minutes);
+        return d.toSeconds() * 20L;
+    }
+
+    /** Resolve player's kingdom. */
     private static Kingdom getKingdom(Player player) {
-        me.continent.village.Village v = me.continent.village.VillageManager.getByPlayer(player.getUniqueId());
+        Village v = VillageManager.getByPlayer(player.getUniqueId());
         if (v == null) return null;
         String kName = v.getKingdom();
         if (kName == null) return null;
         return KingdomManager.getByName(kName);
     }
 
-    static class TreeHolder implements org.bukkit.inventory.InventoryHolder {
+    // ------------------------------------------------------- Holders
+
+    static class TreeHolder implements InventoryHolder {
         private final Kingdom kingdom;
-        private Inventory inventory;
+        private Inventory inv;
         TreeHolder(Kingdom kingdom) { this.kingdom = kingdom; }
-        void setInventory(Inventory inv) { this.inventory = inv; }
-        @Override
-        public Inventory getInventory() { return inventory; }
+        void setInventory(Inventory inv) { this.inv = inv; }
+        @Override public Inventory getInventory() { return inv; }
         public Kingdom getKingdom() { return kingdom; }
     }
 
-    static class NodeHolder implements org.bukkit.inventory.InventoryHolder {
+    static class NodeHolder implements InventoryHolder {
         private final Kingdom kingdom;
         private final String tree;
-        private Inventory inventory;
-        NodeHolder(Kingdom kingdom, String tree) {
-            this.kingdom = kingdom;
-            this.tree = tree;
-        }
-        void setInventory(Inventory inv) { this.inventory = inv; }
-        @Override
-        public Inventory getInventory() { return inventory; }
+        private Inventory inv;
+        NodeHolder(Kingdom kingdom, String tree) { this.kingdom = kingdom; this.tree = tree; }
+        void setInventory(Inventory inv) { this.inv = inv; }
+        @Override public Inventory getInventory() { return inv; }
         public Kingdom getKingdom() { return kingdom; }
         public String getTree() { return tree; }
     }
+
+    // ------------------------------------------------------- Task
+
+    /** Represents an active research task. */
+    private static class ResearchTask extends BukkitRunnable {
+        private final Kingdom kingdom;
+        private final ResearchNode node;
+        private final long maxTicks;
+        private long tick;
+        private BossBar bar;
+
+        ResearchTask(Kingdom kingdom, ResearchNode node, long maxTicks) {
+            this.kingdom = kingdom;
+            this.node = node;
+            this.maxTicks = maxTicks == 0 ? 20L : maxTicks;
+        }
+
+        void start() {
+            bar = Bukkit.createBossBar("연구 진행: " + node.getId(), BarColor.BLUE, BarStyle.SEGMENTED_10);
+            addPlayers(bar, kingdom);
+            runTaskTimer(ContinentPlugin.getInstance(), 0L, 20L);
+        }
+
+        @Override
+        public void run() {
+            tick += 20L;
+            if (bar != null) {
+                bar.setProgress(Math.min(1.0, tick / (double) maxTicks));
+            }
+            if (tick >= maxTicks) {
+                complete();
+                cancel();
+            }
+        }
+
+        private void complete() {
+            if (bar != null) bar.removeAll();
+            kingdom.getResearchedNodes().add(node.getId());
+            if (node.getId().equals("INF_1_RESEARCH_SLOT_1") || node.getId().equals("INF_2_RESEARCH_SLOT_2")) {
+                kingdom.setResearchSlots(kingdom.getResearchSlots() + 1);
+            }
+            KingdomStorage.save(kingdom);
+            tasks.remove(kingdom.getName() + ":" + node.getId());
+        }
+    }
+
+    /** Add all online players of a kingdom to a boss bar. */
+    private static void addPlayers(BossBar bar, Kingdom kingdom) {
+        for (String vName : kingdom.getVillages()) {
+            Village v = VillageManager.getByName(vName);
+            if (v == null) continue;
+            for (UUID uuid : v.getMembers()) {
+                Player p = Bukkit.getPlayer(uuid);
+                if (p != null && p.isOnline()) {
+                    bar.addPlayer(p);
+                }
+            }
+        }
+    }
 }
+

--- a/continent/src/main/java/me/continent/research/ResearchState.java
+++ b/continent/src/main/java/me/continent/research/ResearchState.java
@@ -1,0 +1,8 @@
+package me.continent.research;
+
+public enum ResearchState {
+    LOCKED,
+    AVAILABLE,
+    IN_PROGRESS,
+    COMPLETED
+}


### PR DESCRIPTION
## Summary
- extend kingdom data model with research tree selections and slots
- persist new research data in `KingdomStorage`
- add a comprehensive `ResearchManager` with tree selection and node GUIs
- manage research progress with a boss bar and node states
- update listener for new GUI interaction logic

## Testing
- `./gradlew build -x test`

------
https://chatgpt.com/codex/tasks/task_e_687cfa7c70808324bd5d91f18678bd8c