### PR TITLE
Add flag and symbol features

### DIFF
--- a/continent/src/main/java/me/continent/command/KingdomCommand.java
+++ b/continent/src/main/java/me/continent/command/KingdomCommand.java
@@ -33,6 +33,7 @@ public class KingdomCommand implements TabExecutor {
             player.sendMessage("§e/kingdom members §7- 소속 마을 목록");
             player.sendMessage("§e/kingdom setcapital <마을명> §7- 수도 변경");
             player.sendMessage("§e/kingdom setking <플레이어> §7- 국왕 위임");
+            player.sendMessage("§e/kingdom setflag §7- 국기 설정");
             player.sendMessage("§e/kingdom addvillage <마을명> §7- 마을 초대");
             player.sendMessage("§e/kingdom removevillage <마을명> §7- 마을 제외");
             player.sendMessage("§e/kingdom accept <국가명> §7- 초대 수락");
@@ -201,6 +202,28 @@ public class KingdomCommand implements TabExecutor {
             kingdom.setLeader(tId);
             KingdomStorage.save(kingdom);
             Bukkit.broadcastMessage("§e[국가] " + kingdom.getName() + "의 새로운 국왕은 " + (target.getName() != null ? target.getName() : tId) + "입니다.");
+            return true;
+        }
+
+        if (args[0].equalsIgnoreCase("setflag")) {
+            Village village = VillageManager.getByPlayer(player.getUniqueId());
+            if (village == null || village.getKingdom() == null) {
+                player.sendMessage("§c소속된 국가가 없습니다.");
+                return true;
+            }
+            Kingdom kingdom = KingdomManager.getByName(village.getKingdom());
+            if (!kingdom.getLeader().equals(player.getUniqueId())) {
+                player.sendMessage("§c국왕만 국기를 변경할 수 있습니다.");
+                return true;
+            }
+            org.bukkit.inventory.ItemStack item = player.getInventory().getItemInMainHand();
+            if (item == null || item.getType() == org.bukkit.Material.AIR || !item.getType().name().endsWith("_BANNER")) {
+                player.sendMessage("§c손에 배너를 들고 있어야 합니다.");
+                return true;
+            }
+            kingdom.setFlag(item.clone());
+            KingdomStorage.save(kingdom);
+            player.sendMessage("§a국기가 업데이트되었습니다.");
             return true;
         }
 
@@ -465,7 +488,7 @@ public class KingdomCommand implements TabExecutor {
     public List<String> onTabComplete(CommandSender sender, Command command, String alias, String[] args) {
         List<String> subs = Arrays.asList(
                 "create", "disband", "info", "list", "members", "setcapital",
-                "setking", "addvillage", "removevillage", "accept", "deny",
+                "setking", "setflag", "addvillage", "removevillage", "accept", "deny",
                 "leave", "treasury", "specialty", "chat", "spawn"
         );
 

--- a/continent/src/main/java/me/continent/command/VillageCommand.java
+++ b/continent/src/main/java/me/continent/command/VillageCommand.java
@@ -46,6 +46,7 @@ public class VillageCommand implements TabExecutor {
             player.sendMessage("§e/village setcore §7- 코어 위치 이동");
             player.sendMessage("§e/village spawn §7- 마을 스폰으로 이동");
             player.sendMessage("§e/village chest §7- 마을 창고 열기");
+            player.sendMessage("§e/village setsymbol §7- 상징 아이템 설정");
             player.sendMessage("§e/village ignite <on|off> §7- 아군 점화 허용 토글");
             player.sendMessage("§e/village upkeep §7- 현재 유지비 확인");
             player.sendMessage("§e/village treasury <subcommand> §7- 금고 관리");
@@ -525,6 +526,23 @@ public class VillageCommand implements TabExecutor {
             return true;
         }
 
+        if (args[0].equalsIgnoreCase("setsymbol")) {
+            Village village = VillageManager.getByPlayer(player.getUniqueId());
+            if (village == null || !village.isAuthorized(player.getUniqueId())) {
+                player.sendMessage("§c국왕만 상징 아이템을 변경할 수 있습니다.");
+                return true;
+            }
+            org.bukkit.inventory.ItemStack item = player.getInventory().getItemInMainHand();
+            if (item == null || item.getType() == org.bukkit.Material.AIR) {
+                player.sendMessage("§c손에 아이템을 들고 있어야 합니다.");
+                return true;
+            }
+            village.setSymbol(item.clone());
+            VillageStorage.save(village);
+            player.sendMessage("§a상징 아이템이 업데이트되었습니다.");
+            return true;
+        }
+
         if (args[0].equalsIgnoreCase("upkeep")) {
             Village village = VillageManager.getByPlayer(player.getUniqueId());
             if (village == null) {
@@ -612,7 +630,7 @@ public class VillageCommand implements TabExecutor {
         List<String> subs = Arrays.asList(
                 "create", "disband", "claim", "invite", "invites", "accept", "deny",
                 "members", "leave", "kick", "rename", "list", "setspawn", "setcore",
-                "spawn", "chest", "ignite", "upkeep", "treasury", "confirm", "chat"
+                "spawn", "chest", "setsymbol", "ignite", "upkeep", "treasury", "confirm", "chat"
         );
 
         if (args.length == 1) {

--- a/continent/src/main/java/me/continent/kingdom/Kingdom.java
+++ b/continent/src/main/java/me/continent/kingdom/Kingdom.java
@@ -19,12 +19,14 @@ public class Kingdom {
     private final Set<String> selectedResearchTrees = new HashSet<>();
     private final Set<String> selectedT4Nodes = new HashSet<>();
     private int researchSlots = 1;
+    private org.bukkit.inventory.ItemStack flag;
 
     public Kingdom(String name, UUID leader, Village capital) {
         this.name = name;
         this.leader = leader;
         this.capital = capital.getName();
         this.villages.add(capital.getName());
+        this.flag = new org.bukkit.inventory.ItemStack(org.bukkit.Material.WHITE_BANNER);
     }
 
     public String getName() {
@@ -121,5 +123,13 @@ public class Kingdom {
 
     public void setResearchSlots(int researchSlots) {
         this.researchSlots = researchSlots;
+    }
+
+    public org.bukkit.inventory.ItemStack getFlag() {
+        return flag;
+    }
+
+    public void setFlag(org.bukkit.inventory.ItemStack flag) {
+        this.flag = flag;
     }
 }

--- a/continent/src/main/java/me/continent/kingdom/KingdomStorage.java
+++ b/continent/src/main/java/me/continent/kingdom/KingdomStorage.java
@@ -4,6 +4,8 @@ import me.continent.ContinentPlugin;
 import org.bukkit.configuration.file.FileConfiguration;
 import org.bukkit.configuration.file.YamlConfiguration;
 import me.continent.village.VillageManager;
+import me.continent.utils.ItemSerialization;
+import org.bukkit.inventory.ItemStack;
 
 import java.io.File;
 import java.io.IOException;
@@ -28,6 +30,7 @@ public class KingdomStorage {
         config.set("maintenanceCount", kingdom.getMaintenanceCount());
         config.set("unpaidWeeks", kingdom.getUnpaidWeeks());
         config.set("lastMaintenance", kingdom.getLastMaintenance());
+        config.set("flag", ItemSerialization.serializeItem(kingdom.getFlag()));
         config.set("researched", new ArrayList<>(kingdom.getResearchedNodes()));
         config.set("specialties", new ArrayList<>(kingdom.getSpecialties()));
         config.set("researchSlots", kingdom.getResearchSlots());
@@ -66,6 +69,7 @@ public class KingdomStorage {
             int researchSlots = config.getInt("researchSlots", 1);
             List<String> selectedTrees = config.getStringList("selectedTrees");
             List<String> selectedT4 = config.getStringList("selectedT4");
+            org.bukkit.inventory.ItemStack flag = ItemSerialization.deserializeItem(config.getString("flag"));
             Map<String, Object> rolesObj = config.getConfigurationSection("roles") != null ? config.getConfigurationSection("roles").getValues(false) : new HashMap<>();
 
             Kingdom kingdom = new Kingdom(name, leader, VillageManager.getByName(capitalName));
@@ -77,6 +81,9 @@ public class KingdomStorage {
             kingdom.getResearchedNodes().addAll(researched);
             kingdom.getSpecialties().addAll(specialties);
             kingdom.setResearchSlots(researchSlots);
+            if (flag != null) {
+                kingdom.setFlag(flag);
+            }
             kingdom.getSelectedResearchTrees().addAll(selectedTrees);
             kingdom.getSelectedT4Nodes().addAll(selectedT4);
             for (Map.Entry<String, Object> e : rolesObj.entrySet()) {

--- a/continent/src/main/java/me/continent/storage/VillageStorage.java
+++ b/continent/src/main/java/me/continent/storage/VillageStorage.java
@@ -15,6 +15,7 @@ import org.bukkit.util.io.BukkitObjectOutputStream;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.util.Base64;
+import me.continent.utils.ItemSerialization;
 
 import java.io.File;
 import java.io.IOException;
@@ -49,6 +50,7 @@ public class VillageStorage {
         config.set("protectionEnd", village.getProtectionEnd());
         config.set("vault", village.getVault());
         config.set("chest", serializeItems(village.getChestContents()));
+        config.set("symbol", ItemSerialization.serializeItem(village.getSymbol()));
         config.set("memberIgnite", village.isMemberIgniteAllowed());
         config.set("maintenanceCount", village.getMaintenanceCount());
         config.set("unpaidWeeks", village.getUnpaidWeeks());
@@ -81,6 +83,7 @@ public class VillageStorage {
             long protectionEnd = config.getLong("protectionEnd");
             double vault = config.contains("vault") ? config.getDouble("vault") : config.getDouble("treasury");
             ItemStack[] chest = deserializeItems(config.getString("chest"));
+            org.bukkit.inventory.ItemStack symbol = ItemSerialization.deserializeItem(config.getString("symbol"));
             boolean memberIgnite = config.getBoolean("memberIgnite", false);
             int maintenanceCount = config.getInt("maintenanceCount", 0);
             int unpaidWeeks = config.getInt("unpaidWeeks", 0);
@@ -97,6 +100,9 @@ public class VillageStorage {
             village.setProtectionEnd(protectionEnd);
             village.setVault(vault);
             village.setChestContents(chest);
+            if (symbol != null) {
+                village.setSymbol(symbol);
+            }
             village.setMemberIgniteAllowed(memberIgnite);
             village.setMaintenanceCount(maintenanceCount);
             village.setUnpaidWeeks(unpaidWeeks);

--- a/continent/src/main/java/me/continent/utils/ItemSerialization.java
+++ b/continent/src/main/java/me/continent/utils/ItemSerialization.java
@@ -1,0 +1,39 @@
+package me.continent.utils;
+
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.util.io.BukkitObjectOutputStream;
+import org.bukkit.util.io.BukkitObjectInputStream;
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.util.Base64;
+
+public class ItemSerialization {
+    public static String serializeItem(ItemStack item) {
+        if (item == null) return "";
+        try {
+            ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+            BukkitObjectOutputStream dataOutput = new BukkitObjectOutputStream(outputStream);
+            dataOutput.writeObject(item);
+            dataOutput.close();
+            return Base64.getEncoder().encodeToString(outputStream.toByteArray());
+        } catch (IOException e) {
+            e.printStackTrace();
+            return "";
+        }
+    }
+
+    public static ItemStack deserializeItem(String data) {
+        if (data == null || data.isEmpty()) return null;
+        try {
+            ByteArrayInputStream inputStream = new ByteArrayInputStream(Base64.getDecoder().decode(data));
+            BukkitObjectInputStream dataInput = new BukkitObjectInputStream(inputStream);
+            ItemStack item = (ItemStack) dataInput.readObject();
+            dataInput.close();
+            return item;
+        } catch (IOException | ClassNotFoundException e) {
+            e.printStackTrace();
+            return null;
+        }
+    }
+}

--- a/continent/src/main/java/me/continent/village/Village.java
+++ b/continent/src/main/java/me/continent/village/Village.java
@@ -38,6 +38,9 @@ public class Village {
     // 마을 창고 (27칸 단일 체스트)
     private org.bukkit.inventory.ItemStack[] chestContents = new org.bukkit.inventory.ItemStack[27];
 
+    // Village symbol item
+    private org.bukkit.inventory.ItemStack symbol;
+
 
     public Village(String name, UUID king) {
         this.name = name;
@@ -46,6 +49,7 @@ public class Village {
         this.vault = 0;
         this.kingdom = null;
         this.protectionUntil = System.currentTimeMillis() + 7 * 24 * 60 * 60 * 1000L; // 7일
+        this.symbol = new org.bukkit.inventory.ItemStack(org.bukkit.Material.WOODEN_SWORD);
     }
 
     public static Location getGroundLocation(Location loc) {
@@ -156,6 +160,14 @@ public class Village {
         } else {
             this.chestContents = java.util.Arrays.copyOf(items, 27);
         }
+    }
+
+    public org.bukkit.inventory.ItemStack getSymbol() {
+        return symbol;
+    }
+
+    public void setSymbol(org.bukkit.inventory.ItemStack symbol) {
+        this.symbol = symbol;
     }
 
 


### PR DESCRIPTION
## Summary
- allow setting a banner as a kingdom flag
- allow setting an item as a village symbol
- store flag and symbol in YAML storage
- include serialization helper for single ItemStack

## Testing
- `./gradlew build --console=plain | tail -n 20`

------
https://chatgpt.com/codex/tasks/task_e_687e31130e848324add03eeedf2d98d3