### PR TITLE
Implement kingdom main menu GUI

### DIFF
--- a/continent/src/main/java/me/continent/ContinentPlugin.java
+++ b/continent/src/main/java/me/continent/ContinentPlugin.java
@@ -87,6 +87,11 @@ public class ContinentPlugin extends JavaPlugin {
         getServer().getPluginManager().registerEvents(new ResearchListener(), this);
         getServer().getPluginManager().registerEvents(new me.continent.specialty.SpecialtyListener(), this);
         getServer().getPluginManager().registerEvents(new KingdomSpecialtyListener(), this);
+        getServer().getPluginManager().registerEvents(new me.continent.kingdom.service.KingdomMenuListener(), this);
+        getServer().getPluginManager().registerEvents(new me.continent.kingdom.service.KingdomChestListener(), this);
+        getServer().getPluginManager().registerEvents(new me.continent.kingdom.service.KingdomTreasuryListener(), this);
+        getServer().getPluginManager().registerEvents(new me.continent.kingdom.service.KingdomManageListener(), this);
+        getServer().getPluginManager().registerEvents(new me.continent.kingdom.service.KingdomVillageManageListener(), this);
 
 
 

--- a/continent/src/main/java/me/continent/command/KingdomCommand.java
+++ b/continent/src/main/java/me/continent/command/KingdomCommand.java
@@ -25,6 +25,21 @@ public class KingdomCommand implements TabExecutor {
         }
 
         if (args.length == 0) {
+            Village village = VillageManager.getByPlayer(player.getUniqueId());
+            if (village == null || village.getKingdom() == null) {
+                player.sendMessage("§c소속된 국가가 없습니다.");
+                return true;
+            }
+            Kingdom kingdom = KingdomManager.getByName(village.getKingdom());
+            if (kingdom == null) {
+                player.sendMessage("§c국가 정보를 불러올 수 없습니다.");
+                return true;
+            }
+            me.continent.kingdom.service.KingdomMenuService.openMenu(player, kingdom);
+            return true;
+        }
+
+        if (args[0].equalsIgnoreCase("help")) {
             player.sendMessage("§6[Kingdom 명령어]");
             player.sendMessage("§e/kingdom create <이름> [수도] §7- 국가 생성");
             player.sendMessage("§e/kingdom disband §7- 국가 해산");
@@ -489,7 +504,7 @@ public class KingdomCommand implements TabExecutor {
         List<String> subs = Arrays.asList(
                 "create", "disband", "info", "list", "members", "setcapital",
                 "setking", "setflag", "addvillage", "removevillage", "accept", "deny",
-                "leave", "treasury", "specialty", "chat", "spawn"
+                "leave", "treasury", "specialty", "chat", "spawn", "help"
         );
 
         if (args.length == 1) {

--- a/continent/src/main/java/me/continent/kingdom/Kingdom.java
+++ b/continent/src/main/java/me/continent/kingdom/Kingdom.java
@@ -20,6 +20,9 @@ public class Kingdom {
     private final Set<String> selectedT4Nodes = new HashSet<>();
     private int researchSlots = 1;
     private org.bukkit.inventory.ItemStack flag;
+    private String description = "";
+    private org.bukkit.inventory.ItemStack[] chestContents = new org.bukkit.inventory.ItemStack[27];
+    private double taxRate = 0;
 
     public Kingdom(String name, UUID leader, Village capital) {
         this.name = name;
@@ -131,5 +134,33 @@ public class Kingdom {
 
     public void setFlag(org.bukkit.inventory.ItemStack flag) {
         this.flag = flag;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+
+    public void setDescription(String description) {
+        this.description = description == null ? "" : description;
+    }
+
+    public org.bukkit.inventory.ItemStack[] getChestContents() {
+        return chestContents;
+    }
+
+    public void setChestContents(org.bukkit.inventory.ItemStack[] items) {
+        if (items == null) {
+            this.chestContents = new org.bukkit.inventory.ItemStack[27];
+        } else {
+            this.chestContents = java.util.Arrays.copyOf(items, 27);
+        }
+    }
+
+    public double getTaxRate() {
+        return taxRate;
+    }
+
+    public void setTaxRate(double taxRate) {
+        this.taxRate = taxRate;
     }
 }

--- a/continent/src/main/java/me/continent/kingdom/KingdomManager.java
+++ b/continent/src/main/java/me/continent/kingdom/KingdomManager.java
@@ -60,4 +60,23 @@ public class KingdomManager {
         capital.setVault(0);
         return kingdom;
     }
+
+    public static boolean renameKingdom(Kingdom kingdom, String newName) {
+        if (kingdomsByName.containsKey(newName.toLowerCase())) return false;
+        String old = kingdom.getName();
+        kingdomsByName.remove(old.toLowerCase());
+        kingdom.setName(newName);
+        kingdomsByName.put(newName.toLowerCase(), kingdom);
+        for (String vName : kingdom.getVillages()) {
+            kingdomsByVillage.put(vName.toLowerCase(), kingdom);
+            Village v = VillageManager.getByName(vName);
+            if (v != null) {
+                v.setKingdom(newName);
+                me.continent.storage.VillageStorage.save(v);
+            }
+        }
+        KingdomStorage.rename(old, newName);
+        KingdomStorage.save(kingdom);
+        return true;
+    }
 }

--- a/continent/src/main/java/me/continent/kingdom/KingdomStorage.java
+++ b/continent/src/main/java/me/continent/kingdom/KingdomStorage.java
@@ -27,6 +27,9 @@ public class KingdomStorage {
         config.set("capital", kingdom.getCapital());
         config.set("villages", new ArrayList<>(kingdom.getVillages()));
         config.set("treasury", kingdom.getTreasury());
+        config.set("description", kingdom.getDescription());
+        config.set("chest", me.continent.storage.VillageStorage.serializeItems(kingdom.getChestContents()));
+        config.set("taxRate", kingdom.getTaxRate());
         config.set("maintenanceCount", kingdom.getMaintenanceCount());
         config.set("unpaidWeeks", kingdom.getUnpaidWeeks());
         config.set("lastMaintenance", kingdom.getLastMaintenance());
@@ -61,6 +64,9 @@ public class KingdomStorage {
             String capitalName = config.getString("capital");
             List<String> villages = config.getStringList("villages");
             double treasury = config.getDouble("treasury");
+            String description = config.getString("description", "");
+            org.bukkit.inventory.ItemStack[] chest = me.continent.storage.VillageStorage.deserializeItems(config.getString("chest"));
+            double taxRate = config.getDouble("taxRate", 0);
             int maintenanceCount = config.getInt("maintenanceCount", 0);
             int unpaidWeeks = config.getInt("unpaidWeeks", 0);
             long lastMaintenance = config.getLong("lastMaintenance", 0);
@@ -75,6 +81,9 @@ public class KingdomStorage {
             Kingdom kingdom = new Kingdom(name, leader, VillageManager.getByName(capitalName));
             kingdom.getVillages().addAll(villages);
             kingdom.setTreasury(treasury);
+            kingdom.setDescription(description);
+            kingdom.setChestContents(chest);
+            kingdom.setTaxRate(taxRate);
             kingdom.setMaintenanceCount(maintenanceCount);
             kingdom.setUnpaidWeeks(unpaidWeeks);
             kingdom.setLastMaintenance(lastMaintenance);
@@ -102,5 +111,13 @@ public class KingdomStorage {
     public static void delete(Kingdom kingdom) {
         File file = new File(folder, kingdom.getName().toLowerCase() + ".yml");
         if (file.exists()) file.delete();
+    }
+
+    public static void rename(String oldName, String newName) {
+        File oldFile = new File(folder, oldName.toLowerCase() + ".yml");
+        File newFile = new File(folder, newName.toLowerCase() + ".yml");
+        if (oldFile.exists()) {
+            oldFile.renameTo(newFile);
+        }
     }
 }

--- a/continent/src/main/java/me/continent/kingdom/service/KingdomChestListener.java
+++ b/continent/src/main/java/me/continent/kingdom/service/KingdomChestListener.java
@@ -1,0 +1,20 @@
+package me.continent.kingdom.service;
+
+import me.continent.kingdom.Kingdom;
+import me.continent.kingdom.KingdomStorage;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+import org.bukkit.event.inventory.InventoryCloseEvent;
+import org.bukkit.inventory.Inventory;
+
+public class KingdomChestListener implements Listener {
+    @EventHandler
+    public void onClose(InventoryCloseEvent event) {
+        Inventory inv = event.getInventory();
+        if (inv.getHolder() instanceof KingdomChestService.KingdomChestHolder holder) {
+            Kingdom kingdom = holder.getKingdom();
+            kingdom.setChestContents(inv.getContents());
+            KingdomStorage.save(kingdom);
+        }
+    }
+}

--- a/continent/src/main/java/me/continent/kingdom/service/KingdomChestService.java
+++ b/continent/src/main/java/me/continent/kingdom/service/KingdomChestService.java
@@ -1,0 +1,28 @@
+package me.continent.kingdom.service;
+
+import me.continent.kingdom.Kingdom;
+import me.continent.kingdom.KingdomStorage;
+import org.bukkit.Bukkit;
+import org.bukkit.entity.Player;
+import org.bukkit.inventory.Inventory;
+import org.bukkit.inventory.InventoryHolder;
+
+public class KingdomChestService {
+    public static void openChest(Player player, Kingdom kingdom) {
+        KingdomChestHolder holder = new KingdomChestHolder(kingdom);
+        Inventory inv = Bukkit.createInventory(holder, 27, "Kingdom Chest");
+        holder.setInventory(inv);
+        inv.setContents(kingdom.getChestContents());
+        player.openInventory(inv);
+    }
+
+    static class KingdomChestHolder implements InventoryHolder {
+        private final Kingdom kingdom;
+        private Inventory inventory;
+
+        KingdomChestHolder(Kingdom kingdom) { this.kingdom = kingdom; }
+        void setInventory(Inventory inv) { this.inventory = inv; }
+        Kingdom getKingdom() { return kingdom; }
+        @Override public Inventory getInventory() { return inventory; }
+    }
+}

--- a/continent/src/main/java/me/continent/kingdom/service/KingdomManageListener.java
+++ b/continent/src/main/java/me/continent/kingdom/service/KingdomManageListener.java
@@ -1,0 +1,32 @@
+package me.continent.kingdom.service;
+
+import me.continent.kingdom.Kingdom;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+import org.bukkit.event.inventory.InventoryClickEvent;
+import org.bukkit.inventory.Inventory;
+import org.bukkit.entity.Player;
+
+public class KingdomManageListener implements Listener {
+    @EventHandler
+    public void onClick(InventoryClickEvent event) {
+        Inventory inv = event.getInventory();
+        if (inv.getHolder() instanceof KingdomManageService.ManageHolder holder) {
+            event.setCancelled(true);
+            int slot = event.getRawSlot();
+            Player player = (Player) event.getWhoClicked();
+            Kingdom kingdom = holder.getKingdom();
+            if (slot == 10) {
+                KingdomManageService.promptRename(player, kingdom);
+                player.closeInventory();
+            } else if (slot == 12) {
+                KingdomManageService.promptDescription(player, kingdom);
+                player.closeInventory();
+            } else if (slot == 14) {
+                KingdomVillageManageService.openMenu(player, kingdom);
+            } else if (slot == 16) {
+                player.sendMessage("§e방어권 기능은 아직 구현되지 않았습니다.");
+            }
+        }
+    }
+}

--- a/continent/src/main/java/me/continent/kingdom/service/KingdomManageService.java
+++ b/continent/src/main/java/me/continent/kingdom/service/KingdomManageService.java
@@ -1,0 +1,90 @@
+package me.continent.kingdom.service;
+
+import me.continent.kingdom.Kingdom;
+import me.continent.kingdom.KingdomManager;
+import me.continent.kingdom.KingdomStorage;
+import org.bukkit.Bukkit;
+import org.bukkit.Material;
+import org.bukkit.conversations.ConversationFactory;
+import org.bukkit.conversations.Prompt;
+import org.bukkit.conversations.ConversationContext;
+import org.bukkit.conversations.StringPrompt;
+import org.bukkit.entity.Player;
+import org.bukkit.inventory.Inventory;
+import org.bukkit.inventory.InventoryHolder;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.inventory.meta.ItemMeta;
+
+public class KingdomManageService {
+    public static void openMenu(Player player, Kingdom kingdom) {
+        ManageHolder holder = new ManageHolder(kingdom);
+        Inventory inv = Bukkit.createInventory(holder, 27, "Kingdom Manage");
+        holder.setInventory(inv);
+        inv.setItem(10, createItem(Material.NAME_TAG, "이름 변경"));
+        inv.setItem(12, createItem(Material.BOOK, "설명 변경"));
+        inv.setItem(14, createItem(Material.MAP, "마을 관리"));
+        inv.setItem(16, createItem(Material.SHIELD, "방어권"));
+        player.openInventory(inv);
+    }
+
+    private static ItemStack createItem(Material mat, String name) {
+        ItemStack item = new ItemStack(mat);
+        ItemMeta meta = item.getItemMeta();
+        meta.setDisplayName(name);
+        item.setItemMeta(meta);
+        return item;
+    }
+
+    static class ManageHolder implements InventoryHolder {
+        private final Kingdom kingdom;
+        private Inventory inv;
+        ManageHolder(Kingdom kingdom) { this.kingdom = kingdom; }
+        void setInventory(Inventory inv) { this.inv = inv; }
+        @Override public Inventory getInventory() { return inv; }
+        public Kingdom getKingdom() { return kingdom; }
+    }
+
+    // ---- Prompts ----
+    public static void promptRename(Player player, Kingdom kingdom) {
+        new ConversationFactory(Bukkit.getPluginManager().getPlugin("continent"))
+                .withFirstPrompt(new StringPrompt() {
+                    @Override
+                    public String getPromptText(ConversationContext context) {
+                        return "새 이름을 입력하세요";
+                    }
+
+                    @Override
+                    public Prompt acceptInput(ConversationContext context, String input) {
+                        if (input == null || input.isEmpty()) return END_OF_CONVERSATION;
+                        if (!KingdomManager.renameKingdom(kingdom, input)) {
+                            player.sendMessage("§c이미 존재하는 이름입니다.");
+                        } else {
+                            player.sendMessage("§a이름이 변경되었습니다.");
+                        }
+                        return END_OF_CONVERSATION;
+                    }
+                })
+                .withLocalEcho(false)
+                .buildConversation(player).begin();
+    }
+
+    public static void promptDescription(Player player, Kingdom kingdom) {
+        new ConversationFactory(Bukkit.getPluginManager().getPlugin("continent"))
+                .withFirstPrompt(new StringPrompt() {
+                    @Override
+                    public String getPromptText(ConversationContext context) {
+                        return "새 설명을 입력하세요";
+                    }
+
+                    @Override
+                    public Prompt acceptInput(ConversationContext context, String input) {
+                        kingdom.setDescription(input);
+                        KingdomStorage.save(kingdom);
+                        player.sendMessage("§a설명이 변경되었습니다.");
+                        return END_OF_CONVERSATION;
+                    }
+                })
+                .withLocalEcho(false)
+                .buildConversation(player).begin();
+    }
+}

--- a/continent/src/main/java/me/continent/kingdom/service/KingdomMemberService.java
+++ b/continent/src/main/java/me/continent/kingdom/service/KingdomMemberService.java
@@ -1,0 +1,61 @@
+package me.continent.kingdom.service;
+
+import me.continent.kingdom.Kingdom;
+import me.continent.village.Village;
+import me.continent.village.VillageManager;
+import org.bukkit.Bukkit;
+import org.bukkit.Material;
+import org.bukkit.OfflinePlayer;
+import org.bukkit.entity.Player;
+import org.bukkit.inventory.Inventory;
+import org.bukkit.inventory.InventoryHolder;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.inventory.meta.ItemMeta;
+import org.bukkit.inventory.meta.SkullMeta;
+
+import java.util.*;
+
+public class KingdomMemberService {
+    public static void openMenu(Player player, Kingdom kingdom) {
+        MemberHolder holder = new MemberHolder(kingdom);
+        Inventory inv = Bukkit.createInventory(holder, 27, "Kingdom Members");
+        holder.setInventory(inv);
+
+        OfflinePlayer king = Bukkit.getOfflinePlayer(kingdom.getLeader());
+        ItemStack kingHead = new ItemStack(Material.PLAYER_HEAD);
+        SkullMeta km = (SkullMeta) kingHead.getItemMeta();
+        km.setOwningPlayer(king);
+        km.setDisplayName("§e국왕: " + (king.getName() != null ? king.getName() : king.getUniqueId()));
+        kingHead.setItemMeta(km);
+        inv.setItem(4, kingHead);
+
+        Set<UUID> memberSet = new LinkedHashSet<>();
+        for (String vName : kingdom.getVillages()) {
+            Village v = VillageManager.getByName(vName);
+            if (v != null) memberSet.addAll(v.getMembers());
+        }
+        memberSet.remove(king.getUniqueId());
+        int idx = 9;
+        for (UUID uuid : memberSet) {
+            if (idx >= inv.getSize()) break;
+            OfflinePlayer op = Bukkit.getOfflinePlayer(uuid);
+            ItemStack head = new ItemStack(Material.PLAYER_HEAD);
+            SkullMeta sm = (SkullMeta) head.getItemMeta();
+            sm.setOwningPlayer(op);
+            sm.setDisplayName(op.getName() != null ? op.getName() : uuid.toString());
+            head.setItemMeta(sm);
+            inv.setItem(idx++, head);
+        }
+
+        player.openInventory(inv);
+    }
+
+    static class MemberHolder implements InventoryHolder {
+        private final Kingdom kingdom;
+        private Inventory inv;
+        MemberHolder(Kingdom k) { this.kingdom = k; }
+        void setInventory(Inventory inv) { this.inv = inv; }
+        @Override public Inventory getInventory() { return inv; }
+        public Kingdom getKingdom() { return kingdom; }
+    }
+}

--- a/continent/src/main/java/me/continent/kingdom/service/KingdomMenuListener.java
+++ b/continent/src/main/java/me/continent/kingdom/service/KingdomMenuListener.java
@@ -1,0 +1,43 @@
+package me.continent.kingdom.service;
+
+import me.continent.kingdom.Kingdom;
+import me.continent.village.Village;
+import me.continent.village.VillageManager;
+import org.bukkit.Bukkit;
+import org.bukkit.entity.Player;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+import org.bukkit.event.inventory.InventoryClickEvent;
+import org.bukkit.inventory.Inventory;
+import org.bukkit.inventory.ItemStack;
+
+public class KingdomMenuListener implements Listener {
+    @EventHandler
+    public void onClick(InventoryClickEvent event) {
+        Inventory inv = event.getInventory();
+        if (inv.getHolder() instanceof KingdomMenuService.KingdomMenuHolder holder) {
+            event.setCancelled(true);
+            int slot = event.getRawSlot();
+            Player player = (Player) event.getWhoClicked();
+            Kingdom kingdom = holder.getKingdom();
+            if (slot == 13) {
+                // management menu placeholder
+                KingdomManageService.openMenu(player, kingdom);
+            } else if (slot == 19) {
+                KingdomMemberService.openMenu(player, kingdom);
+            } else if (slot == 21) {
+                KingdomTreasuryService.openMenu(player, kingdom);
+            } else if (slot == 23) {
+                Village capital = VillageManager.getByName(kingdom.getCapital());
+                if (capital != null && capital.getSpawnLocation() != null) {
+                    player.teleport(capital.getSpawnLocation());
+                    player.sendMessage("§a수도로 이동했습니다.");
+                } else {
+                    player.sendMessage("§c수도 스폰이 설정되어 있지 않습니다.");
+                }
+            } else if (slot == 25) {
+                KingdomChestService.openChest(player, kingdom);
+            }
+        }
+    }
+}

--- a/continent/src/main/java/me/continent/kingdom/service/KingdomMenuService.java
+++ b/continent/src/main/java/me/continent/kingdom/service/KingdomMenuService.java
@@ -1,0 +1,62 @@
+package me.continent.kingdom.service;
+
+import me.continent.kingdom.Kingdom;
+import org.bukkit.Bukkit;
+import org.bukkit.OfflinePlayer;
+import org.bukkit.Material;
+import org.bukkit.entity.Player;
+import org.bukkit.inventory.Inventory;
+import org.bukkit.inventory.InventoryHolder;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.inventory.meta.ItemMeta;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class KingdomMenuService {
+    public static void openMenu(Player player, Kingdom kingdom) {
+        KingdomMenuHolder holder = new KingdomMenuHolder(kingdom);
+        Inventory inv = Bukkit.createInventory(holder, 36, "Kingdom Menu");
+        holder.setInventory(inv);
+
+        // banner
+        ItemStack banner = kingdom.getFlag() == null ? new ItemStack(Material.WHITE_BANNER) : kingdom.getFlag().clone();
+        ItemMeta meta = banner.getItemMeta();
+        meta.setDisplayName("§a국가 관리");
+        List<String> lore = new ArrayList<>();
+        lore.add("§f이름: §e" + kingdom.getName());
+        lore.add("§f설명: §e" + kingdom.getDescription());
+        lore.add("§f수도: §e" + kingdom.getCapital());
+        OfflinePlayer king = Bukkit.getOfflinePlayer(kingdom.getLeader());
+        lore.add("§f국왕: §e" + (king.getName() != null ? king.getName() : king.getUniqueId()));
+        lore.add("§f마을: §e" + String.join(", ", kingdom.getVillages()));
+        lore.add("§f국고: §e" + kingdom.getTreasury() + "G");
+        meta.setLore(lore);
+        banner.setItemMeta(meta);
+        inv.setItem(13, banner);
+
+        inv.setItem(19, createItem(Material.PLAYER_HEAD, "구성원"));
+        inv.setItem(21, createItem(Material.GOLD_INGOT, "국고 관리"));
+        inv.setItem(23, createItem(Material.COMPASS, "국가 스폰 이동"));
+        inv.setItem(25, createItem(Material.CHEST, "국가 창고"));
+
+        player.openInventory(inv);
+    }
+
+    private static ItemStack createItem(Material mat, String name) {
+        ItemStack item = new ItemStack(mat);
+        ItemMeta meta = item.getItemMeta();
+        meta.setDisplayName(name);
+        item.setItemMeta(meta);
+        return item;
+    }
+
+    static class KingdomMenuHolder implements InventoryHolder {
+        private final Kingdom kingdom;
+        private Inventory inv;
+        KingdomMenuHolder(Kingdom kingdom) { this.kingdom = kingdom; }
+        void setInventory(Inventory inv) { this.inv = inv; }
+        @Override public Inventory getInventory() { return inv; }
+        public Kingdom getKingdom() { return kingdom; }
+    }
+}

--- a/continent/src/main/java/me/continent/kingdom/service/KingdomTreasuryListener.java
+++ b/continent/src/main/java/me/continent/kingdom/service/KingdomTreasuryListener.java
@@ -1,0 +1,31 @@
+package me.continent.kingdom.service;
+
+import me.continent.kingdom.Kingdom;
+import org.bukkit.entity.Player;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+import org.bukkit.event.inventory.InventoryClickEvent;
+import org.bukkit.inventory.Inventory;
+
+public class KingdomTreasuryListener implements Listener {
+    @EventHandler
+    public void onClick(InventoryClickEvent event) {
+        Inventory inv = event.getInventory();
+        if (inv.getHolder() instanceof KingdomTreasuryService.TreasuryHolder holder) {
+            event.setCancelled(true);
+            Player player = (Player) event.getWhoClicked();
+            int slot = event.getRawSlot();
+            Kingdom kingdom = holder.getKingdom();
+            if (slot == 2) {
+                KingdomTreasuryService.promptDeposit(player, kingdom);
+                player.closeInventory();
+            } else if (slot == 4) {
+                KingdomTreasuryService.promptWithdraw(player, kingdom);
+                player.closeInventory();
+            } else if (slot == 6) {
+                KingdomTreasuryService.promptTax(player, kingdom);
+                player.closeInventory();
+            }
+        }
+    }
+}

--- a/continent/src/main/java/me/continent/kingdom/service/KingdomTreasuryService.java
+++ b/continent/src/main/java/me/continent/kingdom/service/KingdomTreasuryService.java
@@ -1,0 +1,133 @@
+package me.continent.kingdom.service;
+
+import me.continent.ContinentPlugin;
+import me.continent.kingdom.Kingdom;
+import me.continent.kingdom.KingdomStorage;
+import me.continent.player.PlayerData;
+import me.continent.player.PlayerDataManager;
+import org.bukkit.Bukkit;
+import org.bukkit.Material;
+import org.bukkit.conversations.ConversationContext;
+import org.bukkit.conversations.ConversationFactory;
+import org.bukkit.conversations.NumericPrompt;
+import org.bukkit.conversations.Prompt;
+import org.bukkit.entity.Player;
+import org.bukkit.inventory.Inventory;
+import org.bukkit.inventory.InventoryHolder;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.inventory.meta.ItemMeta;
+
+public class KingdomTreasuryService {
+    public static void openMenu(Player player, Kingdom kingdom) {
+        TreasuryHolder holder = new TreasuryHolder(kingdom);
+        Inventory inv = Bukkit.createInventory(holder, 9, "Kingdom Treasury");
+        holder.setInventory(inv);
+        inv.setItem(2, createItem(Material.EMERALD_BLOCK, "입금"));
+        inv.setItem(4, createItem(Material.REDSTONE_BLOCK, "출금"));
+        inv.setItem(6, createItem(Material.PAPER, "세율: " + kingdom.getTaxRate() + "%"));
+        player.openInventory(inv);
+    }
+
+    private static ItemStack createItem(Material mat, String name) {
+        ItemStack item = new ItemStack(mat);
+        ItemMeta meta = item.getItemMeta();
+        meta.setDisplayName(name);
+        item.setItemMeta(meta);
+        return item;
+    }
+
+    static class TreasuryHolder implements InventoryHolder {
+        private final Kingdom kingdom;
+        private Inventory inv;
+        TreasuryHolder(Kingdom k) { this.kingdom = k; }
+        void setInventory(Inventory inv) { this.inv = inv; }
+        @Override public Inventory getInventory() { return inv; }
+        public Kingdom getKingdom() { return kingdom; }
+    }
+
+    // ---- prompts ----
+    public static void promptDeposit(Player player, Kingdom kingdom) {
+        new ConversationFactory(ContinentPlugin.getInstance())
+                .withFirstPrompt(new NumericPrompt() {
+                    @Override
+                    public String getPromptText(ConversationContext context) {
+                        return "입금할 금액을 입력하세요";
+                    }
+
+                    @Override
+                    protected Prompt acceptValidatedInput(ConversationContext context, Number number) {
+                        int amount = number.intValue();
+                        PlayerData data = PlayerDataManager.get(player.getUniqueId());
+                        if (amount <= 0 || data.getGold() < amount) {
+                            player.sendMessage("§c입금할 수 없습니다.");
+                        } else if (!kingdom.getLeader().equals(player.getUniqueId())) {
+                            player.sendMessage("§c국왕만 입금할 수 있습니다.");
+                        } else {
+                            data.removeGold(amount);
+                            kingdom.addGold(amount);
+                            PlayerDataManager.save(player.getUniqueId());
+                            KingdomStorage.save(kingdom);
+                            player.sendMessage("§a입금 완료: " + amount + "G");
+                        }
+                        return END_OF_CONVERSATION;
+                    }
+                })
+                .withLocalEcho(false)
+                .buildConversation(player).begin();
+    }
+
+    public static void promptWithdraw(Player player, Kingdom kingdom) {
+        new ConversationFactory(ContinentPlugin.getInstance())
+                .withFirstPrompt(new NumericPrompt() {
+                    @Override
+                    public String getPromptText(ConversationContext context) {
+                        return "출금할 금액을 입력하세요";
+                    }
+
+                    @Override
+                    protected Prompt acceptValidatedInput(ConversationContext context, Number number) {
+                        int amount = number.intValue();
+                        if (amount <= 0 || kingdom.getTreasury() < amount) {
+                            player.sendMessage("§c출금할 수 없습니다.");
+                        } else if (!kingdom.getLeader().equals(player.getUniqueId())) {
+                            player.sendMessage("§c국왕만 출금할 수 있습니다.");
+                        } else {
+                            kingdom.removeGold(amount);
+                            PlayerData data = PlayerDataManager.get(player.getUniqueId());
+                            data.addGold(amount);
+                            PlayerDataManager.save(player.getUniqueId());
+                            KingdomStorage.save(kingdom);
+                            player.sendMessage("§a출금 완료: " + amount + "G");
+                        }
+                        return END_OF_CONVERSATION;
+                    }
+                })
+                .withLocalEcho(false)
+                .buildConversation(player).begin();
+    }
+
+    public static void promptTax(Player player, Kingdom kingdom) {
+        new ConversationFactory(ContinentPlugin.getInstance())
+                .withFirstPrompt(new NumericPrompt() {
+                    @Override
+                    public String getPromptText(ConversationContext context) {
+                        return "세율을 입력하세요 (0-100)";
+                    }
+
+                    @Override
+                    protected Prompt acceptValidatedInput(ConversationContext context, Number number) {
+                        double rate = number.doubleValue();
+                        if (rate < 0 || rate > 100) {
+                            player.sendMessage("§c0에서 100 사이의 값을 입력하세요.");
+                        } else {
+                            kingdom.setTaxRate(rate);
+                            KingdomStorage.save(kingdom);
+                            player.sendMessage("§a세율이 설정되었습니다: " + rate + "%");
+                        }
+                        return END_OF_CONVERSATION;
+                    }
+                })
+                .withLocalEcho(false)
+                .buildConversation(player).begin();
+    }
+}

--- a/continent/src/main/java/me/continent/kingdom/service/KingdomVillageManageListener.java
+++ b/continent/src/main/java/me/continent/kingdom/service/KingdomVillageManageListener.java
@@ -1,0 +1,48 @@
+package me.continent.kingdom.service;
+
+import me.continent.kingdom.Kingdom;
+import me.continent.kingdom.KingdomManager;
+import me.continent.kingdom.KingdomStorage;
+import me.continent.village.Village;
+import me.continent.village.VillageManager;
+import me.continent.storage.VillageStorage;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+import org.bukkit.event.inventory.InventoryClickEvent;
+import org.bukkit.inventory.Inventory;
+import org.bukkit.entity.Player;
+
+public class KingdomVillageManageListener implements Listener {
+    @EventHandler
+    public void onClick(InventoryClickEvent event) {
+        Inventory inv = event.getInventory();
+        if (inv.getHolder() instanceof KingdomVillageManageService.VillageHolder holder) {
+            event.setCancelled(true);
+            Player player = (Player) event.getWhoClicked();
+            Kingdom kingdom = holder.getKingdom();
+            int slot = event.getRawSlot();
+            if (slot >= inv.getSize()) return;
+            var item = inv.getItem(slot);
+            if (item == null || !item.hasItemMeta()) return;
+            String name = item.getItemMeta().getDisplayName();
+            Village v = VillageManager.getByName(name);
+            if (v == null) return;
+            if (event.isLeftClick()) {
+                kingdom.setCapital(name);
+                KingdomStorage.save(kingdom);
+                player.sendMessage("§a수도가 변경되었습니다.");
+                KingdomVillageManageService.openMenu(player, kingdom);
+            } else if (event.isRightClick()) {
+                if (name.equalsIgnoreCase(kingdom.getCapital())) {
+                    player.sendMessage("§c수도는 제외할 수 없습니다.");
+                    return;
+                }
+                KingdomManager.removeVillage(kingdom, v);
+                KingdomStorage.save(kingdom);
+                VillageStorage.save(v);
+                player.sendMessage("§e" + name + " 마을이 제외되었습니다.");
+                KingdomVillageManageService.openMenu(player, kingdom);
+            }
+        }
+    }
+}

--- a/continent/src/main/java/me/continent/kingdom/service/KingdomVillageManageService.java
+++ b/continent/src/main/java/me/continent/kingdom/service/KingdomVillageManageService.java
@@ -1,0 +1,54 @@
+package me.continent.kingdom.service;
+
+import me.continent.kingdom.Kingdom;
+import me.continent.kingdom.KingdomManager;
+import me.continent.kingdom.KingdomStorage;
+import me.continent.village.Village;
+import me.continent.village.VillageManager;
+import me.continent.storage.VillageStorage;
+import org.bukkit.Bukkit;
+import org.bukkit.Material;
+import org.bukkit.entity.Player;
+import org.bukkit.inventory.Inventory;
+import org.bukkit.inventory.InventoryHolder;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.inventory.meta.ItemMeta;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class KingdomVillageManageService {
+    public static void openMenu(Player player, Kingdom kingdom) {
+        int size = ((kingdom.getVillages().size() + 8) / 9) * 9;
+        VillageHolder holder = new VillageHolder(kingdom);
+        Inventory inv = Bukkit.createInventory(holder, Math.max(9, size), "Village Manage");
+        holder.setInventory(inv);
+        int slot = 0;
+        for (String vName : kingdom.getVillages()) {
+            Village v = VillageManager.getByName(vName);
+            ItemStack item = (v != null && v.getSymbol() != null) ? v.getSymbol().clone() : new ItemStack(Material.PAPER);
+            ItemMeta meta = item.getItemMeta();
+            meta.setDisplayName(vName);
+            List<String> lore = new ArrayList<>();
+            if (vName.equalsIgnoreCase(kingdom.getCapital())) {
+                lore.add("§e수도");
+            } else {
+                lore.add("§7왼클릭: 수도 지정");
+                lore.add("§7우클릭: 제외");
+            }
+            meta.setLore(lore);
+            item.setItemMeta(meta);
+            inv.setItem(slot++, item);
+        }
+        player.openInventory(inv);
+    }
+
+    static class VillageHolder implements InventoryHolder {
+        private final Kingdom kingdom;
+        private Inventory inv;
+        VillageHolder(Kingdom k) { this.kingdom = k; }
+        void setInventory(Inventory inv) { this.inv = inv; }
+        @Override public Inventory getInventory() { return inv; }
+        public Kingdom getKingdom() { return kingdom; }
+    }
+}


### PR DESCRIPTION
## Summary
- add new properties for kingdoms (description, chest, tax)
- implement multiple services for kingdom GUI menus and storage
- show GUI when `/kingdom` is used and move help to `/kingdom help`
- register GUI listeners in plugin

## Testing
- `./gradlew build`

------
https://chatgpt.com/codex/tasks/task_e_687e3425ac608324a16862d4a0fe087f