### PR TITLE
Implement nation-level protection toggle

### DIFF
--- a/continent/src/main/java/me/continent/listener/TerritoryListener.java
+++ b/continent/src/main/java/me/continent/listener/TerritoryListener.java
@@ -2,6 +2,8 @@ package me.continent.listener;
 
 import me.continent.village.Village;
 import me.continent.village.VillageManager;
+import me.continent.nation.nationManager;
+import me.continent.nation.nation;
 import me.continent.ContinentPlugin;
 import org.bukkit.Bukkit;
 import org.bukkit.Chunk;
@@ -47,6 +49,10 @@ public class TerritoryListener implements Listener {
         Village playerVillage = VillageManager.getByPlayer(uuid);
 
         if (toVillage != null && (playerVillage == null || !toVillage.getMembers().contains(uuid))) {
+            if (toVillage.getnation() != null) {
+                nation k = nationManager.getByName(toVillage.getnation());
+                if (k != null && !k.isTerritoryProtectionEnabled()) return;
+            }
             // entering foreign village
             if (!toVillage.equals(currentIntrusion.get(uuid))) {
                 cancelAlert(uuid);

--- a/continent/src/main/java/me/continent/nation/nation.java
+++ b/continent/src/main/java/me/continent/nation/nation.java
@@ -23,6 +23,7 @@ public class nation {
     private String description = "";
     private org.bukkit.inventory.ItemStack[] chestContents = new org.bukkit.inventory.ItemStack[27];
     private double taxRate = 0;
+    private boolean territoryProtection = true;
 
     public nation(String name, UUID leader, Village capital) {
         this.name = name;
@@ -162,5 +163,13 @@ public class nation {
 
     public void setTaxRate(double taxRate) {
         this.taxRate = taxRate;
+    }
+
+    public boolean isTerritoryProtectionEnabled() {
+        return territoryProtection;
+    }
+
+    public void setTerritoryProtectionEnabled(boolean enabled) {
+        this.territoryProtection = enabled;
     }
 }

--- a/continent/src/main/java/me/continent/nation/nationStorage.java
+++ b/continent/src/main/java/me/continent/nation/nationStorage.java
@@ -30,6 +30,7 @@ public class nationStorage {
         config.set("description", kingdom.getDescription());
         config.set("chest", me.continent.storage.VillageStorage.serializeItems(kingdom.getChestContents()));
         config.set("taxRate", kingdom.getTaxRate());
+        config.set("territoryProtection", kingdom.isTerritoryProtectionEnabled());
         config.set("maintenanceCount", kingdom.getMaintenanceCount());
         config.set("unpaidWeeks", kingdom.getUnpaidWeeks());
         config.set("lastMaintenance", kingdom.getLastMaintenance());
@@ -67,6 +68,7 @@ public class nationStorage {
             String description = config.getString("description", "");
             org.bukkit.inventory.ItemStack[] chest = me.continent.storage.VillageStorage.deserializeItems(config.getString("chest"));
             double taxRate = config.getDouble("taxRate", 0);
+            boolean territoryProtection = config.getBoolean("territoryProtection", true);
             int maintenanceCount = config.getInt("maintenanceCount", 0);
             int unpaidWeeks = config.getInt("unpaidWeeks", 0);
             long lastMaintenance = config.getLong("lastMaintenance", 0);
@@ -84,6 +86,7 @@ public class nationStorage {
             kingdom.setDescription(description);
             kingdom.setChestContents(chest);
             kingdom.setTaxRate(taxRate);
+            kingdom.setTerritoryProtectionEnabled(territoryProtection);
             kingdom.setMaintenanceCount(maintenanceCount);
             kingdom.setUnpaidWeeks(unpaidWeeks);
             kingdom.setLastMaintenance(lastMaintenance);

--- a/continent/src/main/java/me/continent/nation/service/nationManageListener.java
+++ b/continent/src/main/java/me/continent/nation/service/nationManageListener.java
@@ -25,7 +25,11 @@ public class nationManageListener implements Listener {
             } else if (slot == 14) {
                 nationVillageManageService.openMenu(player, kingdom);
             } else if (slot == 16) {
-                player.sendMessage("§e방어권 기능은 아직 구현되지 않았습니다.");
+                boolean newState = !kingdom.isTerritoryProtectionEnabled();
+                kingdom.setTerritoryProtectionEnabled(newState);
+                me.continent.nation.nationStorage.save(kingdom);
+                player.sendMessage("§a방어권이 " + (newState ? "활성화" : "비활성화") + "되었습니다.");
+                nationManageService.openMenu(player, kingdom);
             }
         }
     }

--- a/continent/src/main/java/me/continent/nation/service/nationManageService.java
+++ b/continent/src/main/java/me/continent/nation/service/nationManageService.java
@@ -23,7 +23,9 @@ public class nationManageService {
         inv.setItem(10, createItem(Material.NAME_TAG, "이름 변경"));
         inv.setItem(12, createItem(Material.BOOK, "설명 변경"));
         inv.setItem(14, createItem(Material.MAP, "마을 관리"));
-        inv.setItem(16, createItem(Material.SHIELD, "방어권"));
+        String state = kingdom.isTerritoryProtectionEnabled() ? "ON" : "OFF";
+        Material mat = kingdom.isTerritoryProtectionEnabled() ? Material.SHIELD : Material.BARRIER;
+        inv.setItem(16, createItem(mat, "방어권: " + state));
         player.openInventory(inv);
     }
 

--- a/continent/src/main/java/me/continent/protection/CoreProtectionListener.java
+++ b/continent/src/main/java/me/continent/protection/CoreProtectionListener.java
@@ -3,6 +3,8 @@ package me.continent.protection;
 import me.continent.village.Village;
 import me.continent.village.VillageManager;
 import me.continent.war.WarManager;
+import me.continent.nation.nationManager;
+import me.continent.nation.nation;
 import org.bukkit.Location;
 import org.bukkit.block.Block;
 import org.bukkit.event.EventHandler;
@@ -36,6 +38,10 @@ public class CoreProtectionListener implements Listener {
                 event.setCancelled(true);
                 return;
             }
+            if (owner.getnation() != null) {
+                nation k = nationManager.getByName(owner.getnation());
+                if (k != null && !k.isTerritoryProtectionEnabled()) return;
+            }
             Village attackerVillage = VillageManager.getByPlayer(event.getPlayer().getUniqueId());
             boolean allowed = attackerVillage != null
                     && owner.getnation() != null
@@ -53,11 +59,27 @@ public class CoreProtectionListener implements Listener {
 
     @EventHandler
     public void onBlockExplode(BlockExplodeEvent event) {
-        event.blockList().removeIf(this::isCoreBlock);
+        event.blockList().removeIf(block -> {
+            if (!isCoreBlock(block)) return false;
+            Village v = VillageManager.getByChunk(block.getChunk());
+            if (v != null && v.getnation() != null) {
+                nation k = nationManager.getByName(v.getnation());
+                if (k != null && !k.isTerritoryProtectionEnabled()) return false;
+            }
+            return true;
+        });
     }
 
     @EventHandler
     public void onEntityExplode(EntityExplodeEvent event) {
-        event.blockList().removeIf(this::isCoreBlock);
+        event.blockList().removeIf(block -> {
+            if (!isCoreBlock(block)) return false;
+            Village v = VillageManager.getByChunk(block.getChunk());
+            if (v != null && v.getnation() != null) {
+                nation k = nationManager.getByName(v.getnation());
+                if (k != null && !k.isTerritoryProtectionEnabled()) return false;
+            }
+            return true;
+        });
     }
 }

--- a/continent/src/main/java/me/continent/protection/ProtectionStateListener.java
+++ b/continent/src/main/java/me/continent/protection/ProtectionStateListener.java
@@ -2,6 +2,8 @@ package me.continent.protection;
 
 import me.continent.village.Village;
 import me.continent.village.VillageManager;
+import me.continent.nation.nationManager;
+import me.continent.nation.nation;
 import org.bukkit.Chunk;
 import org.bukkit.Material;
 import org.bukkit.block.Block;
@@ -27,8 +29,10 @@ public class ProtectionStateListener implements Listener {
         Village village = VillageManager.getByChunk(block.getChunk());
         if (village == null) return false;
         if (!village.isUnderProtection()) return false;
-        if (village.getnation() != null && me.continent.war.WarManager.getWar(village.getnation()) != null) {
-            return false;
+        if (village.getnation() != null) {
+            if (me.continent.war.WarManager.getWar(village.getnation()) != null) return false;
+            nation k = nationManager.getByName(village.getnation());
+            if (k != null && !k.isTerritoryProtectionEnabled()) return false;
         }
         return true;
     }
@@ -38,8 +42,10 @@ public class ProtectionStateListener implements Listener {
         Village village = VillageManager.getByChunk(chunk);
         if (village == null) return false;
         if (!village.isUnderProtection()) return false;
-        if (village.getnation() != null && me.continent.war.WarManager.getWar(village.getnation()) != null) {
-            return false;
+        if (village.getnation() != null) {
+            if (me.continent.war.WarManager.getWar(village.getnation()) != null) return false;
+            nation k = nationManager.getByName(village.getnation());
+            if (k != null && !k.isTerritoryProtectionEnabled()) return false;
         }
         return true;
     }

--- a/continent/src/main/java/me/continent/protection/TerritoryProtectionListener.java
+++ b/continent/src/main/java/me/continent/protection/TerritoryProtectionListener.java
@@ -3,6 +3,8 @@ package me.continent.protection;
 import me.continent.village.Village;
 import me.continent.village.VillageManager;
 import me.continent.war.WarManager;
+import me.continent.nation.nationManager;
+import me.continent.nation.nation;
 import org.bukkit.Chunk;
 import org.bukkit.Material;
 import org.bukkit.block.Block;
@@ -29,6 +31,10 @@ public class TerritoryProtectionListener implements Listener {
 
         Village owner = VillageManager.getByChunk(chunk);
         if (owner == null) return; // 야생
+        if (owner.getnation() != null) {
+            nation k = nationManager.getByName(owner.getnation());
+            if (k != null && !k.isTerritoryProtectionEnabled()) return;
+        }
 
         Village playerVillage = VillageManager.getByPlayer(player.getUniqueId());
 
@@ -53,6 +59,10 @@ public class TerritoryProtectionListener implements Listener {
 
         Village owner = VillageManager.getByChunk(chunk);
         if (owner == null) return;
+        if (owner.getnation() != null) {
+            nation k = nationManager.getByName(owner.getnation());
+            if (k != null && !k.isTerritoryProtectionEnabled()) return;
+        }
 
         Village playerVillage = VillageManager.getByPlayer(player.getUniqueId());
 
@@ -76,9 +86,15 @@ public class TerritoryProtectionListener implements Listener {
             // farmland trampling
             if (event.getClickedBlock().getType() == Material.FARMLAND) {
                 Village owner = VillageManager.getByChunk(event.getClickedBlock().getChunk());
-                if (owner != null && !owner.getMembers().contains(event.getPlayer().getUniqueId())) {
-                    event.setCancelled(true);
-                    return;
+                if (owner != null) {
+                    if (owner.getnation() != null) {
+                        nation k = nationManager.getByName(owner.getnation());
+                        if (k != null && !k.isTerritoryProtectionEnabled()) return;
+                    }
+                    if (!owner.getMembers().contains(event.getPlayer().getUniqueId())) {
+                        event.setCancelled(true);
+                        return;
+                    }
                 }
             }
         }
@@ -86,6 +102,10 @@ public class TerritoryProtectionListener implements Listener {
         if (event.getAction() == Action.RIGHT_CLICK_BLOCK && event.getClickedBlock() != null) {
             Village owner = VillageManager.getByChunk(event.getClickedBlock().getChunk());
             if (owner == null) return;
+            if (owner.getnation() != null) {
+                nation k = nationManager.getByName(owner.getnation());
+                if (k != null && !k.isTerritoryProtectionEnabled()) return;
+            }
 
             Village playerVillage = VillageManager.getByPlayer(event.getPlayer().getUniqueId());
             boolean allowed = false;
@@ -108,6 +128,14 @@ public class TerritoryProtectionListener implements Listener {
         Chunk chunk = event.getBlock().getChunk();
         Village owner = VillageManager.getByChunk(chunk);
         if (owner == null) return;
+        if (owner.getnation() != null) {
+            nation k = nationManager.getByName(owner.getnation());
+            if (k != null && !k.isTerritoryProtectionEnabled()) return;
+        }
+        if (owner.getnation() != null) {
+            nation k = nationManager.getByName(owner.getnation());
+            if (k != null && !k.isTerritoryProtectionEnabled()) return;
+        }
 
         Village playerVillage = VillageManager.getByPlayer(event.getPlayer().getUniqueId());
         boolean allowed = false;
@@ -152,6 +180,10 @@ public class TerritoryProtectionListener implements Listener {
 
         Village owner = VillageManager.getByChunk(event.getEntity().getLocation().getChunk());
         if (owner == null) return;
+        if (owner.getnation() != null) {
+            nation k = nationManager.getByName(owner.getnation());
+            if (k != null && !k.isTerritoryProtectionEnabled()) return;
+        }
 
         Village playerVillage = VillageManager.getByPlayer(player.getUniqueId());
         boolean allowed = false;
@@ -170,11 +202,27 @@ public class TerritoryProtectionListener implements Listener {
 
     @EventHandler
     public void onBlockExplode(BlockExplodeEvent event) {
-        event.blockList().removeIf(block -> VillageManager.getByChunk(block.getChunk()) != null);
+        event.blockList().removeIf(block -> {
+            Village v = VillageManager.getByChunk(block.getChunk());
+            if (v == null) return false;
+            if (v.getnation() != null) {
+                nation k = nationManager.getByName(v.getnation());
+                if (k != null && !k.isTerritoryProtectionEnabled()) return false;
+            }
+            return true;
+        });
     }
 
     @EventHandler
     public void onEntityExplode(EntityExplodeEvent event) {
-        event.blockList().removeIf(block -> VillageManager.getByChunk(block.getChunk()) != null);
+        event.blockList().removeIf(block -> {
+            Village v = VillageManager.getByChunk(block.getChunk());
+            if (v == null) return false;
+            if (v.getnation() != null) {
+                nation k = nationManager.getByName(v.getnation());
+                if (k != null && !k.isTerritoryProtectionEnabled()) return false;
+            }
+            return true;
+        });
     }
 }


### PR DESCRIPTION
## Summary
- add `territoryProtection` flag to `nation`
- persist new flag in `nationStorage`
- allow toggling protection in nation management GUI
- respect flag in all protection listeners

## Testing
- `./gradlew build -x test`

------
https://chatgpt.com/codex/tasks/task_e_687e6b0b9598832495caf33a15173414