### PR TITLE
Fix war settlement and improve /nation completions

### DIFF
--- a/continent/src/main/java/me/continent/command/nationCommand.java
+++ b/continent/src/main/java/me/continent/command/nationCommand.java
@@ -533,12 +533,32 @@ public class nationCommand implements TabExecutor {
                     .toList();
         }
 
-        if (args.length == 2 && (args[0].equalsIgnoreCase("setking") || args[0].equalsIgnoreCase("addvillage")
-                || args[0].equalsIgnoreCase("removevillage"))) {
-            return Bukkit.getOnlinePlayers().stream()
-                    .map(Player::getName)
-                    .filter(n -> n.toLowerCase().startsWith(args[1].toLowerCase()))
-                    .toList();
+        if (args.length == 2) {
+            if (args[0].equalsIgnoreCase("setking")) {
+                return Bukkit.getOnlinePlayers().stream()
+                        .map(Player::getName)
+                        .filter(n -> n.toLowerCase().startsWith(args[1].toLowerCase()))
+                        .toList();
+            }
+            if (args[0].equalsIgnoreCase("addvillage")) {
+                return VillageManager.getAll().stream()
+                        .filter(v -> v.getnation() == null)
+                        .map(Village::getName)
+                        .filter(n -> n.toLowerCase().startsWith(args[1].toLowerCase()))
+                        .toList();
+            }
+            if (args[0].equalsIgnoreCase("removevillage") && sender instanceof Player p) {
+                Village v = VillageManager.getByPlayer(p.getUniqueId());
+                if (v != null && v.getnation() != null) {
+                    nation kingdom = nationManager.getByName(v.getnation());
+                    if (kingdom != null) {
+                        return kingdom.getVillages().stream()
+                                .filter(name -> !name.equalsIgnoreCase(kingdom.getCapital()))
+                                .filter(name -> name.toLowerCase().startsWith(args[1].toLowerCase()))
+                                .toList();
+                    }
+                }
+            }
         }
 
         return Collections.emptyList();

--- a/continent/src/main/java/me/continent/war/WarManager.java
+++ b/continent/src/main/java/me/continent/war/WarManager.java
@@ -53,11 +53,19 @@ public class WarManager {
             Village village = VillageManager.getByName(entry.getKey());
             nation capturer = nationManager.getByName(entry.getValue());
             if (village == null || capturer == null) continue;
-            if (village.getCoreLocation() != null && village.getCoreLocation().getBlock().getType() != Material.BEACON) {
+
+            // restore core block if missing
+            if (village.getCoreLocation() != null
+                    && village.getCoreLocation().getBlock().getType() != Material.BEACON) {
                 CoreService.placeCore(village, village.getCoreLocation());
             }
+
+            // transfer village ownership
             if (!capturer.getVillages().contains(village.getName())) {
                 nationManager.addVillage(capturer, village);
+                // persist updated data for both capturer nation and village
+                nationStorage.save(capturer);
+                VillageStorage.save(village);
             }
         }
 


### PR DESCRIPTION
## Summary
- persist village ownership when wars end so captured villages remain with the victor
- provide better tab completions for `/nation` subcommands

## Testing
- `./gradlew build -x test`

------
https://chatgpt.com/codex/tasks/task_e_687e9331aa6c8324ae93cdd76d3eb617