### PR TITLE
Add gold command GUI

### DIFF
--- a/continent/src/main/java/me/continent/ContinentPlugin.java
+++ b/continent/src/main/java/me/continent/ContinentPlugin.java
@@ -92,6 +92,7 @@ public class ContinentPlugin extends JavaPlugin {
         getServer().getPluginManager().registerEvents(new NationMenuListener(), this);
         getServer().getPluginManager().registerEvents(new NationTreasuryListener(), this);
         getServer().getPluginManager().registerEvents(new ServerMenuListener(), this);
+        getServer().getPluginManager().registerEvents(new me.continent.economy.gui.GoldMenuListener(), this);
 
 
         getServer().getPluginManager().registerEvents(new MarketListener(), this);

--- a/continent/src/main/java/me/continent/command/GoldCommand.java
+++ b/continent/src/main/java/me/continent/command/GoldCommand.java
@@ -1,6 +1,7 @@
 package me.continent.command;
 
 import me.continent.economy.CentralBank;
+import me.continent.economy.gui.GoldMenuService;
 import org.bukkit.Bukkit;
 import me.continent.player.PlayerData;
 import me.continent.player.PlayerDataManager;
@@ -20,13 +21,18 @@ public class GoldCommand implements TabExecutor {
             return true;
         }
 
-        // ✅ 도움말 출력 (인자 없음)
-        if (args.length == 0) {
+        if (args.length == 0 || args[0].equalsIgnoreCase("gui")) {
+            GoldMenuService.openMenu(player);
+            return true;
+        }
+
+        if (args[0].equalsIgnoreCase("help")) {
             player.sendMessage("§6[골드 명령어 도움말]");
             player.sendMessage("§e/gold convert <수량> §7- 골드를 사용해 금괴를 획득합니다.");
             player.sendMessage("§e/gold exchange [수량] §7- 금을 골드로 환전합니다.");
             player.sendMessage("§e/gold balance §7- 현재 보유 골드를 확인합니다.");
             player.sendMessage("§e/gold pay <플레이어> <금액> §7- 플레이어에게 골드를 송금합니다.");
+            player.sendMessage("§e/gold gui §7- 골드 메뉴 열기");
             return true;
         }
 

--- a/continent/src/main/java/me/continent/economy/gui/GoldExchangeGUI.java
+++ b/continent/src/main/java/me/continent/economy/gui/GoldExchangeGUI.java
@@ -1,0 +1,122 @@
+package me.continent.economy.gui;
+
+import me.continent.economy.CentralBank;
+import me.continent.player.PlayerData;
+import me.continent.player.PlayerDataManager;
+import org.bukkit.Bukkit;
+import org.bukkit.Material;
+import org.bukkit.entity.Player;
+import org.bukkit.inventory.Inventory;
+import org.bukkit.inventory.InventoryHolder;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.inventory.meta.ItemMeta;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class GoldExchangeGUI {
+    public enum Mode { CONVERT, EXCHANGE }
+
+    public static void open(Player player, Mode mode, int qty) {
+        Holder holder = new Holder(mode, qty);
+        Inventory inv = Bukkit.createInventory(holder, 45, mode == Mode.CONVERT ? "Gold -> Ingot" : "Ingot -> Gold");
+        holder.setInventory(inv);
+        fill(inv);
+        renderButtons(inv, mode, qty);
+        player.openInventory(inv);
+    }
+
+    static void renderButtons(Inventory inv, Mode mode, int qty) {
+        inv.setItem(22, new ItemStack(Material.GOLD_INGOT));
+        inv.setItem(20, qtyButton(Material.REDSTONE, "-10", qty - 10));
+        inv.setItem(21, qtyButton(Material.REDSTONE, "-1", qty - 1));
+        inv.setItem(23, qtyButton(Material.LIME_DYE, "+1", qty + 1));
+        inv.setItem(24, qtyButton(Material.LIME_DYE, "+10", qty + 10));
+        if (qty < 1) qty = 1;
+        double rate = CentralBank.getExchangeRate();
+        int total = (int) Math.round(rate * qty);
+        String name = mode == Mode.CONVERT ? "비용: " + total + "G" : "수익: " + total + "G";
+        ItemStack price = new ItemStack(Material.GOLD_INGOT);
+        ItemMeta pm = price.getItemMeta();
+        pm.setDisplayName(name);
+        price.setItemMeta(pm);
+        inv.setItem(31, price);
+        inv.setItem(38, createButton(Material.BARRIER, "취소"));
+        inv.setItem(40, createButton(Material.EMERALD_BLOCK, "확인"));
+    }
+
+    private static ItemStack createButton(Material mat, String name) {
+        ItemStack item = new ItemStack(mat);
+        ItemMeta meta = item.getItemMeta();
+        meta.setDisplayName(name);
+        item.setItemMeta(meta);
+        return item;
+    }
+
+    private static void fill(Inventory inv) {
+        ItemStack pane = new ItemStack(Material.GRAY_STAINED_GLASS_PANE);
+        ItemMeta meta = pane.getItemMeta();
+        meta.setDisplayName(" ");
+        pane.setItemMeta(meta);
+        for (int i = 0; i < inv.getSize(); i++) {
+            inv.setItem(i, pane);
+        }
+    }
+
+    private static ItemStack qtyButton(Material mat, String name, int qty) {
+        if (qty < 1) qty = 1;
+        ItemStack item = new ItemStack(mat);
+        ItemMeta meta = item.getItemMeta();
+        meta.setDisplayName(name);
+        List<String> lore = new ArrayList<>();
+        lore.add("§7수량: " + qty);
+        meta.setLore(lore);
+        item.setItemMeta(meta);
+        return item;
+    }
+
+    static class Holder implements InventoryHolder {
+        private final Mode mode;
+        private int qty;
+        private Inventory inv;
+        Holder(Mode m, int q) { this.mode = m; this.qty = q; }
+        void setInventory(Inventory i) { this.inv = i; }
+        @Override public Inventory getInventory() { return inv; }
+        public Mode getMode() { return mode; }
+        public int getQty() { return qty; }
+        public void setQty(int q) { qty = Math.max(1, q); }
+    }
+
+    public static void perform(Player player, Holder holder) {
+        int qty = holder.getQty();
+        if (qty < 1) qty = 1;
+        double rate = CentralBank.getExchangeRate();
+        int total = (int) Math.round(rate * qty);
+        PlayerData data = PlayerDataManager.get(player.getUniqueId());
+        if (holder.getMode() == Mode.CONVERT) {
+            if (data.getGold() < total) {
+                player.sendMessage("§c골드가 부족합니다. (필요: " + total + "G)");
+                return;
+            }
+            if (player.getInventory().firstEmpty() == -1) {
+                player.sendMessage("§c인벤토리가 부족합니다.");
+                return;
+            }
+            data.removeGold(total);
+            ItemStack ingot = new ItemStack(Material.GOLD_INGOT, qty);
+            player.getInventory().addItem(ingot);
+            player.sendMessage("§e" + total + "G을 사용해 금괴 " + qty + "개를 구매했습니다.");
+        } else {
+            ItemStack ingot = new ItemStack(Material.GOLD_INGOT);
+            if (!player.getInventory().containsAtLeast(ingot, qty)) {
+                player.sendMessage("§c금괴가 부족합니다.");
+                return;
+            }
+            player.getInventory().removeItem(new ItemStack(Material.GOLD_INGOT, qty));
+            data.addGold(total);
+            player.sendMessage("§e금괴 " + qty + "개를 환전해 " + total + "G을 받았습니다.");
+            CentralBank.recordExchange();
+        }
+        PlayerDataManager.save(player.getUniqueId());
+    }
+}

--- a/continent/src/main/java/me/continent/economy/gui/GoldMenuService.java
+++ b/continent/src/main/java/me/continent/economy/gui/GoldMenuService.java
@@ -1,0 +1,38 @@
+package me.continent.economy.gui;
+
+import org.bukkit.Bukkit;
+import org.bukkit.Material;
+import org.bukkit.entity.Player;
+import org.bukkit.inventory.Inventory;
+import org.bukkit.inventory.InventoryHolder;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.inventory.meta.ItemMeta;
+
+public class GoldMenuService {
+    public static void openMenu(Player player) {
+        MenuHolder holder = new MenuHolder();
+        Inventory inv = Bukkit.createInventory(holder, 27, "Gold Menu");
+        holder.setInventory(inv);
+
+        inv.setItem(10, createItem(Material.GOLD_INGOT, "잔액 확인"));
+        inv.setItem(12, createItem(Material.GOLD_BLOCK, "금괴 구매"));
+        inv.setItem(14, createItem(Material.RAW_GOLD, "금 괴 환전"));
+        inv.setItem(16, createItem(Material.PLAYER_HEAD, "송금"));
+
+        player.openInventory(inv);
+    }
+
+    static ItemStack createItem(Material mat, String name) {
+        ItemStack item = new ItemStack(mat);
+        ItemMeta meta = item.getItemMeta();
+        meta.setDisplayName(name);
+        item.setItemMeta(meta);
+        return item;
+    }
+
+    static class MenuHolder implements InventoryHolder {
+        private Inventory inv;
+        void setInventory(Inventory i) { this.inv = i; }
+        @Override public Inventory getInventory() { return inv; }
+    }
+}

--- a/continent/src/main/java/me/continent/economy/gui/GoldPayService.java
+++ b/continent/src/main/java/me/continent/economy/gui/GoldPayService.java
@@ -1,0 +1,125 @@
+package me.continent.economy.gui;
+
+import me.continent.player.PlayerData;
+import me.continent.player.PlayerDataManager;
+import org.bukkit.Bukkit;
+import org.bukkit.Material;
+import org.bukkit.entity.Player;
+import org.bukkit.inventory.Inventory;
+import org.bukkit.inventory.InventoryHolder;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.inventory.meta.ItemMeta;
+import org.bukkit.inventory.meta.SkullMeta;
+
+import java.util.UUID;
+
+public class GoldPayService {
+    public static void openSelect(Player player) {
+        SelectHolder holder = new SelectHolder();
+        Inventory inv = Bukkit.createInventory(holder, 54, "송금 대상 선택");
+        holder.setInventory(inv);
+        int idx = 0;
+        for (Player p : Bukkit.getOnlinePlayers()) {
+            if (p.getUniqueId().equals(player.getUniqueId())) continue;
+            if (idx >= inv.getSize()) break;
+            ItemStack head = new ItemStack(Material.PLAYER_HEAD);
+            SkullMeta meta = (SkullMeta) head.getItemMeta();
+            meta.setOwningPlayer(p);
+            meta.setDisplayName(p.getName());
+            head.setItemMeta(meta);
+            inv.setItem(idx++, head);
+        }
+        player.openInventory(inv);
+    }
+
+    public static void openAmount(Player player, UUID target, int amount) {
+        AmountHolder holder = new AmountHolder(target, amount);
+        Inventory inv = Bukkit.createInventory(holder, 45, "송금 금액 설정");
+        holder.setInventory(inv);
+        fill(inv);
+        render(inv, amount);
+        player.openInventory(inv);
+    }
+
+    static void render(Inventory inv, int amount) {
+        inv.setItem(20, amountButton(Material.REDSTONE, "-10G", amount - 10));
+        inv.setItem(21, amountButton(Material.REDSTONE, "-1G", amount - 1));
+        inv.setItem(23, amountButton(Material.LIME_DYE, "+1G", amount + 1));
+        inv.setItem(24, amountButton(Material.LIME_DYE, "+10G", amount + 10));
+        if (amount < 1) amount = 1;
+        ItemStack amt = new ItemStack(Material.GOLD_INGOT);
+        ItemMeta meta = amt.getItemMeta();
+        meta.setDisplayName("송금: " + amount + "G");
+        amt.setItemMeta(meta);
+        inv.setItem(31, amt);
+        inv.setItem(38, createButton(Material.BARRIER, "취소"));
+        inv.setItem(40, createButton(Material.EMERALD_BLOCK, "송금"));
+    }
+
+    private static ItemStack createButton(Material mat, String name) {
+        ItemStack item = new ItemStack(mat);
+        ItemMeta meta = item.getItemMeta();
+        meta.setDisplayName(name);
+        item.setItemMeta(meta);
+        return item;
+    }
+
+    private static void fill(Inventory inv) {
+        ItemStack pane = new ItemStack(Material.GRAY_STAINED_GLASS_PANE);
+        ItemMeta meta = pane.getItemMeta();
+        meta.setDisplayName(" ");
+        pane.setItemMeta(meta);
+        for (int i = 0; i < inv.getSize(); i++) {
+            inv.setItem(i, pane);
+        }
+    }
+
+    private static ItemStack amountButton(Material mat, String name, int amount) {
+        if (amount < 1) amount = 1;
+        ItemStack item = new ItemStack(mat);
+        ItemMeta meta = item.getItemMeta();
+        meta.setDisplayName(name);
+        meta.setLore(java.util.List.of("§7금액: " + amount + "G"));
+        item.setItemMeta(meta);
+        return item;
+    }
+
+    static class SelectHolder implements InventoryHolder {
+        private Inventory inv;
+        void setInventory(Inventory i) { this.inv = i; }
+        @Override public Inventory getInventory() { return inv; }
+    }
+
+    static class AmountHolder implements InventoryHolder {
+        private final UUID target;
+        private int amount;
+        private Inventory inv;
+        AmountHolder(UUID t, int a) { this.target = t; this.amount = a; }
+        void setInventory(Inventory i) { this.inv = i; }
+        @Override public Inventory getInventory() { return inv; }
+        public UUID getTarget() { return target; }
+        public int getAmount() { return amount; }
+        public void setAmount(int a) { amount = Math.max(1, a); }
+    }
+
+    public static void performPay(Player player, AmountHolder holder) {
+        Player target = Bukkit.getPlayer(holder.getTarget());
+        if (target == null || !target.isOnline()) {
+            player.sendMessage("§c해당 플레이어는 오프라인입니다.");
+            return;
+        }
+        int amount = holder.getAmount();
+        PlayerData sender = PlayerDataManager.get(player.getUniqueId());
+        if (sender.getGold() < amount) {
+            player.sendMessage("§c보유 골드가 부족합니다.");
+            return;
+        }
+        PlayerData receiver = PlayerDataManager.get(target.getUniqueId());
+        sender.removeGold(amount);
+        receiver.addGold(amount);
+        PlayerDataManager.save(player.getUniqueId());
+        PlayerDataManager.save(target.getUniqueId());
+        player.sendMessage("§e" + target.getName() + "에게 " + amount + "G를 송금했습니다.");
+        target.sendMessage("§e" + player.getName() + "로부터 " + amount + "G를 받았습니다.");
+    }
+}


### PR DESCRIPTION
## Summary
- add `GoldMenuService` for a new inventory menu
- support convert/exchange and paying players via GUI
- register `GoldMenuListener`
- open the GUI from `/gold` with no arguments

## Testing
- `./gradlew build`

------
https://chatgpt.com/codex/tasks/task_e_68819d8cdaa48324810d2a24ec2164b8