### PR TITLE
Integrate gold menu into server menu

### DIFF
--- a/continent/src/main/java/me/continent/menu/ServerMenuListener.java
+++ b/continent/src/main/java/me/continent/menu/ServerMenuListener.java
@@ -39,7 +39,8 @@ public class ServerMenuListener implements Listener {
                     player.sendMessage("§f국가: §e" + nationName);
                 }
                 case 37 -> MarketGUI.open(player, 1, MarketManager.SortMode.NEWEST, false);
-                case 16, 40, 43 -> player.sendMessage("§e준비 중인 기능입니다.");
+                case 16 -> me.continent.economy.gui.GoldMenuService.openMenu(player);
+                case 40, 43 -> player.sendMessage("§e준비 중인 기능입니다.");
             }
         }
     }

--- a/continent/src/main/java/me/continent/menu/ServerMenuService.java
+++ b/continent/src/main/java/me/continent/menu/ServerMenuService.java
@@ -33,7 +33,7 @@ public class ServerMenuService {
 
         ItemStack rawGold = new ItemStack(Material.RAW_GOLD);
         ItemMeta gMeta = rawGold.getItemMeta();
-        gMeta.setDisplayName("§a돈");
+        gMeta.setDisplayName("§a골드 메뉴 열기");
         gMeta.setCustomModelData(0);
         rawGold.setItemMeta(gMeta);
         inv.setItem(16, rawGold);


### PR DESCRIPTION
## Summary
- update server menu item text to `골드 메뉴 열기`
- open the new gold menu from the main server menu

## Testing
- `./gradlew build`

------
https://chatgpt.com/codex/tasks/task_e_6881a11543d88324880f0861e0b158ec