### PR TITLE
Update custom model data usage for 1.21.5

### DIFF
--- a/continent/src/main/java/me/continent/market/MarketGUI.java
+++ b/continent/src/main/java/me/continent/market/MarketGUI.java
@@ -9,6 +9,7 @@ import org.bukkit.inventory.Inventory;
 import org.bukkit.inventory.InventoryHolder;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.meta.ItemMeta;
+import org.bukkit.inventory.meta.components.CustomModelDataComponent;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -62,7 +63,9 @@ public class MarketGUI {
         ItemStack item = new ItemStack(mat);
         ItemMeta meta = item.getItemMeta();
         meta.setDisplayName(ChatColor.YELLOW + name);
-        meta.setCustomModelData(1);
+        CustomModelDataComponent btnCmd = meta.getCustomModelDataComponent();
+        btnCmd.setStrings(java.util.List.of("1"));
+        meta.setCustomModelDataComponent(btnCmd);
         item.setItemMeta(meta);
         return item;
     }
@@ -71,7 +74,9 @@ public class MarketGUI {
         ItemStack pane = new ItemStack(Material.BARRIER);
         ItemMeta meta = pane.getItemMeta();
         meta.setDisplayName(" ");
-        meta.setCustomModelData(1);
+        CustomModelDataComponent paneCmd = meta.getCustomModelDataComponent();
+        paneCmd.setStrings(java.util.List.of("1"));
+        meta.setCustomModelDataComponent(paneCmd);
         pane.setItemMeta(meta);
         for (int i = 0; i < inv.getSize(); i++) {
             inv.setItem(i, pane);

--- a/continent/src/main/java/me/continent/menu/ServerMenuService.java
+++ b/continent/src/main/java/me/continent/menu/ServerMenuService.java
@@ -8,6 +8,7 @@ import org.bukkit.inventory.InventoryHolder;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.meta.ItemMeta;
 import org.bukkit.inventory.meta.SkullMeta;
+import org.bukkit.inventory.meta.components.CustomModelDataComponent;
 
 
 public class ServerMenuService {
@@ -19,7 +20,9 @@ public class ServerMenuService {
         ItemStack sword = new ItemStack(Material.NETHERITE_SWORD);
         ItemMeta sMeta = sword.getItemMeta();
         sMeta.setDisplayName("§a국가 메뉴 열기");
-        sMeta.setCustomModelData(0);
+        CustomModelDataComponent swordCmd = sMeta.getCustomModelDataComponent();
+        swordCmd.setStrings(java.util.List.of("0"));
+        sMeta.setCustomModelDataComponent(swordCmd);
         sword.setItemMeta(sMeta);
         inv.setItem(10, sword);
 
@@ -27,35 +30,45 @@ public class ServerMenuService {
         SkullMeta hMeta = (SkullMeta) head.getItemMeta();
         hMeta.setOwningPlayer(player);
         hMeta.setDisplayName("§a플레이어 정보");
-        hMeta.setCustomModelData(0);
+        CustomModelDataComponent headCmd = hMeta.getCustomModelDataComponent();
+        headCmd.setStrings(java.util.List.of("0"));
+        hMeta.setCustomModelDataComponent(headCmd);
         head.setItemMeta(hMeta);
         inv.setItem(13, head);
 
         ItemStack rawGold = new ItemStack(Material.RAW_GOLD);
         ItemMeta gMeta = rawGold.getItemMeta();
         gMeta.setDisplayName("§a골드 메뉴 열기");
-        gMeta.setCustomModelData(0);
+        CustomModelDataComponent goldCmd = gMeta.getCustomModelDataComponent();
+        goldCmd.setStrings(java.util.List.of("0"));
+        gMeta.setCustomModelDataComponent(goldCmd);
         rawGold.setItemMeta(gMeta);
         inv.setItem(16, rawGold);
 
         ItemStack bundle = new ItemStack(Material.BUNDLE);
         ItemMeta bMeta = bundle.getItemMeta();
         bMeta.setDisplayName("§aMarket 메뉴 열기");
-        bMeta.setCustomModelData(0);
+        CustomModelDataComponent bundleCmd = bMeta.getCustomModelDataComponent();
+        bundleCmd.setStrings(java.util.List.of("0"));
+        bMeta.setCustomModelDataComponent(bundleCmd);
         bundle.setItemMeta(bMeta);
         inv.setItem(37, bundle);
 
         ItemStack compass = new ItemStack(Material.COMPASS);
         ItemMeta cMeta = compass.getItemMeta();
         cMeta.setDisplayName("§a워프 기능");
-        cMeta.setCustomModelData(0);
+        CustomModelDataComponent compassCmd = cMeta.getCustomModelDataComponent();
+        compassCmd.setStrings(java.util.List.of("0"));
+        cMeta.setCustomModelDataComponent(compassCmd);
         compass.setItemMeta(cMeta);
         inv.setItem(40, compass);
 
         ItemStack cart = new ItemStack(Material.MINECART);
         ItemMeta cartMeta = cart.getItemMeta();
         cartMeta.setDisplayName("§a직업 기능");
-        cartMeta.setCustomModelData(0);
+        CustomModelDataComponent cartCmd = cartMeta.getCustomModelDataComponent();
+        cartCmd.setStrings(java.util.List.of("0"));
+        cartMeta.setCustomModelDataComponent(cartCmd);
         cart.setItemMeta(cartMeta);
         inv.setItem(43, cart);
 

--- a/continent/src/main/java/me/continent/specialty/SpecialtyGood.java
+++ b/continent/src/main/java/me/continent/specialty/SpecialtyGood.java
@@ -3,6 +3,7 @@ package me.continent.specialty;
 import org.bukkit.Material;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.meta.ItemMeta;
+import org.bukkit.inventory.meta.components.CustomModelDataComponent;
 
 import java.util.List;
 
@@ -47,7 +48,9 @@ public class SpecialtyGood {
         if (meta != null) {
             meta.setDisplayName(name);
             meta.setLore(lore);
-            meta.setCustomModelData(modelData);
+            CustomModelDataComponent cmd = meta.getCustomModelDataComponent();
+            cmd.setStrings(java.util.List.of(String.valueOf(modelData)));
+            meta.setCustomModelDataComponent(cmd);
             item.setItemMeta(meta);
         }
         return item;


### PR DESCRIPTION
## Summary
- replace deprecated `setCustomModelData` calls with `CustomModelDataComponent`
- use string-based custom model data entries

## Testing
- `./gradlew build`

------
https://chatgpt.com/codex/tasks/task_e_6881f4159ff48324a5a99d3590b5262a