### PR TITLE
Add main menu back buttons

### DIFF
--- a/continent/src/main/java/me/continent/ContinentPlugin.java
+++ b/continent/src/main/java/me/continent/ContinentPlugin.java
@@ -22,6 +22,7 @@ import me.continent.nation.service.ChestListener;
 import me.continent.nation.service.MaintenanceService;
 import me.continent.nation.service.NationMenuListener;
 import me.continent.nation.service.NationTreasuryListener;
+import me.continent.nation.service.NationMemberListener;
 import me.continent.menu.ServerMenuListener;
 import org.bukkit.plugin.java.JavaPlugin;
 import me.continent.player.PlayerDataManager;
@@ -91,6 +92,7 @@ public class ContinentPlugin extends JavaPlugin {
         getServer().getPluginManager().registerEvents(new NationSpecialtyListener(), this);
         getServer().getPluginManager().registerEvents(new NationMenuListener(), this);
         getServer().getPluginManager().registerEvents(new NationTreasuryListener(), this);
+        getServer().getPluginManager().registerEvents(new NationMemberListener(), this);
         getServer().getPluginManager().registerEvents(new ServerMenuListener(), this);
         getServer().getPluginManager().registerEvents(new me.continent.economy.gui.GoldMenuListener(), this);
 

--- a/continent/src/main/java/me/continent/economy/gui/GoldExchangeGUI.java
+++ b/continent/src/main/java/me/continent/economy/gui/GoldExchangeGUI.java
@@ -44,6 +44,7 @@ public class GoldExchangeGUI {
         inv.setItem(22, price);
         inv.setItem(38, createButton(Material.BARRIER, "취소"));
         inv.setItem(40, createButton(Material.EMERALD_BLOCK, "확인"));
+        inv.setItem(42, createButton(Material.ARROW, "메인 메뉴"));
     }
 
     private static ItemStack maxButton(Player player, Mode mode) {

--- a/continent/src/main/java/me/continent/economy/gui/GoldMenuListener.java
+++ b/continent/src/main/java/me/continent/economy/gui/GoldMenuListener.java
@@ -2,6 +2,7 @@ package me.continent.economy.gui;
 
 import me.continent.player.PlayerData;
 import me.continent.player.PlayerDataManager;
+import me.continent.menu.ServerMenuService;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
@@ -24,6 +25,7 @@ public class GoldMenuListener implements Listener {
                 case 12 -> GoldExchangeGUI.open(player, GoldExchangeGUI.Mode.CONVERT, 1);
                 case 14 -> GoldExchangeGUI.open(player, GoldExchangeGUI.Mode.EXCHANGE, 1);
                 case 16 -> GoldPayService.openSelect(player);
+                case 22 -> ServerMenuService.openMenu(player);
             }
         } else if (inv.getHolder() instanceof GoldExchangeGUI.Holder holder) {
             event.setCancelled(true);
@@ -37,10 +39,16 @@ public class GoldMenuListener implements Listener {
                 case 41 -> { holder.setQty(GoldExchangeGUI.getMaxQty(player, holder.getMode())); GoldExchangeGUI.renderButtons(inv, player, holder.getMode(), holder.getQty()); }
                 case 38 -> player.closeInventory();
                 case 40 -> { GoldExchangeGUI.perform(player, holder); player.closeInventory(); }
+                case 42 -> ServerMenuService.openMenu(player);
             }
         } else if (inv.getHolder() instanceof GoldPayService.SelectHolder) {
             event.setCancelled(true);
             Player player = (Player) event.getWhoClicked();
+            int slot = event.getRawSlot();
+            if (slot == 53) {
+                ServerMenuService.openMenu(player);
+                return;
+            }
             var item = event.getCurrentItem();
             if (item == null || !item.hasItemMeta()) return;
             var meta = item.getItemMeta();
@@ -59,6 +67,7 @@ public class GoldMenuListener implements Listener {
                 case 24 -> { holder.setAmount(holder.getAmount() + 10); GoldPayService.render(inv, holder.getAmount()); }
                 case 38 -> player.closeInventory();
                 case 40 -> { GoldPayService.performPay(player, holder); player.closeInventory(); }
+                case 42 -> ServerMenuService.openMenu(player);
             }
         }
     }

--- a/continent/src/main/java/me/continent/economy/gui/GoldMenuService.java
+++ b/continent/src/main/java/me/continent/economy/gui/GoldMenuService.java
@@ -18,6 +18,7 @@ public class GoldMenuService {
         inv.setItem(12, createItem(Material.GOLD_BLOCK, "금괴 구매"));
         inv.setItem(14, createItem(Material.RAW_GOLD, "금 괴 환전"));
         inv.setItem(16, createItem(Material.PLAYER_HEAD, "송금"));
+        inv.setItem(22, createItem(Material.ARROW, "메인 메뉴"));
 
         player.openInventory(inv);
     }

--- a/continent/src/main/java/me/continent/economy/gui/GoldPayService.java
+++ b/continent/src/main/java/me/continent/economy/gui/GoldPayService.java
@@ -29,6 +29,7 @@ public class GoldPayService {
             head.setItemMeta(meta);
             inv.setItem(idx++, head);
         }
+        inv.setItem(53, createButton(Material.ARROW, "메인 메뉴"));
         player.openInventory(inv);
     }
 
@@ -54,6 +55,7 @@ public class GoldPayService {
         inv.setItem(31, amt);
         inv.setItem(38, createButton(Material.BARRIER, "취소"));
         inv.setItem(40, createButton(Material.EMERALD_BLOCK, "송금"));
+        inv.setItem(42, createButton(Material.ARROW, "메인 메뉴"));
     }
 
     private static ItemStack createButton(Material mat, String name) {

--- a/continent/src/main/java/me/continent/nation/service/NationMemberListener.java
+++ b/continent/src/main/java/me/continent/nation/service/NationMemberListener.java
@@ -1,0 +1,22 @@
+package me.continent.nation.service;
+
+import org.bukkit.entity.Player;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+import org.bukkit.event.inventory.InventoryClickEvent;
+import org.bukkit.inventory.Inventory;
+import me.continent.menu.ServerMenuService;
+
+public class NationMemberListener implements Listener {
+    @EventHandler
+    public void onClick(InventoryClickEvent event) {
+        Inventory inv = event.getInventory();
+        if (inv.getHolder() instanceof NationMemberService.MemberHolder) {
+            event.setCancelled(true);
+            if (event.getRawSlot() == 26) {
+                Player player = (Player) event.getWhoClicked();
+                ServerMenuService.openMenu(player);
+            }
+        }
+    }
+}

--- a/continent/src/main/java/me/continent/nation/service/NationMemberService.java
+++ b/continent/src/main/java/me/continent/nation/service/NationMemberService.java
@@ -9,6 +9,7 @@ import org.bukkit.inventory.Inventory;
 import org.bukkit.inventory.InventoryHolder;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.meta.SkullMeta;
+import org.bukkit.inventory.meta.ItemMeta;
 
 import java.util.UUID;
 
@@ -39,7 +40,17 @@ public class NationMemberService {
             inv.setItem(idx++, head);
         }
 
+        inv.setItem(26, createArrow());
+
         player.openInventory(inv);
+    }
+
+    private static ItemStack createArrow() {
+        ItemStack item = new ItemStack(Material.ARROW);
+        ItemMeta meta = item.getItemMeta();
+        meta.setDisplayName("메인 메뉴");
+        item.setItemMeta(meta);
+        return item;
     }
 
     static class MemberHolder implements InventoryHolder {

--- a/continent/src/main/java/me/continent/nation/service/NationMenuListener.java
+++ b/continent/src/main/java/me/continent/nation/service/NationMenuListener.java
@@ -6,6 +6,7 @@ import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
 import org.bukkit.event.inventory.InventoryClickEvent;
 import org.bukkit.inventory.Inventory;
+import me.continent.menu.ServerMenuService;
 
 public class NationMenuListener implements Listener {
     @EventHandler
@@ -30,6 +31,8 @@ public class NationMenuListener implements Listener {
                 }
             } else if (slot == 25) {
                 ChestService.openChest(player, nation);
+            } else if (slot == 31) {
+                ServerMenuService.openMenu(player);
             }
         }
     }

--- a/continent/src/main/java/me/continent/nation/service/NationMenuService.java
+++ b/continent/src/main/java/me/continent/nation/service/NationMenuService.java
@@ -36,6 +36,7 @@ public class NationMenuService {
         inv.setItem(21, createItem(Material.GOLD_INGOT, "금고 관리"));
         inv.setItem(23, createItem(Material.COMPASS, "국가 스폰 이동"));
         inv.setItem(25, createItem(Material.CHEST, "국가 창고"));
+        inv.setItem(31, createItem(Material.ARROW, "메인 메뉴"));
 
         player.openInventory(inv);
     }

--- a/continent/src/main/java/me/continent/nation/service/NationTreasuryListener.java
+++ b/continent/src/main/java/me/continent/nation/service/NationTreasuryListener.java
@@ -6,6 +6,7 @@ import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
 import org.bukkit.event.inventory.InventoryClickEvent;
 import org.bukkit.inventory.Inventory;
+import me.continent.menu.ServerMenuService;
 
 public class NationTreasuryListener implements Listener {
     @EventHandler
@@ -22,6 +23,8 @@ public class NationTreasuryListener implements Listener {
             } else if (slot == 4) {
                 NationTreasuryService.promptWithdraw(player, nation);
                 player.closeInventory();
+            } else if (slot == 8) {
+                ServerMenuService.openMenu(player);
             }
         }
     }

--- a/continent/src/main/java/me/continent/nation/service/NationTreasuryService.java
+++ b/continent/src/main/java/me/continent/nation/service/NationTreasuryService.java
@@ -25,6 +25,7 @@ public class NationTreasuryService {
         inv.setItem(2, createItem(Material.EMERALD_BLOCK, "입금"));
         inv.setItem(4, createItem(Material.REDSTONE_BLOCK, "출금"));
         inv.setItem(6, createItem(Material.GOLD_INGOT, "잔액: " + nation.getVault() + "G"));
+        inv.setItem(8, createItem(Material.ARROW, "메인 메뉴"));
         player.openInventory(inv);
     }
 


### PR DESCRIPTION
## Summary
- add `메인 메뉴` arrows in economy and nation GUIs
- handle new back buttons in menu listeners
- register new `NationMemberListener`

## Testing
- `./gradlew -p continent build`

------
https://chatgpt.com/codex/tasks/task_e_68821dbc83b883249727c97264c0c34b