### PR TITLE
Add command usage error messages

### DIFF
--- a/continent/src/main/java/me/continent/command/NationCommand.java
+++ b/continent/src/main/java/me/continent/command/NationCommand.java
@@ -125,7 +125,12 @@ public class NationCommand implements TabExecutor {
             return true;
         }
 
-        if (args[0].equalsIgnoreCase("kick") && args.length >= 2) {
+        if (args[0].equalsIgnoreCase("kick")) {
+            if (args.length < 2) {
+                player.sendMessage("§c사용법: /nation kick <플레이어>");
+                return true;
+            }
+            
             Nation nation = NationManager.getByPlayer(player.getUniqueId());
             if (nation == null || !nation.isAuthorized(player.getUniqueId())) {
                 player.sendMessage("§c국왕만 구성원을 추방할 수 있습니다.");
@@ -151,7 +156,12 @@ public class NationCommand implements TabExecutor {
         }
 
 
-        if (args[0].equalsIgnoreCase("rename") && args.length >= 2) {
+        if (args[0].equalsIgnoreCase("rename")) {
+            if (args.length < 2) {
+                player.sendMessage("§c사용법: /nation rename <새이름>");
+                return true;
+            }
+
             Nation nation = NationManager.getByPlayer(player.getUniqueId());
             if (nation == null || !nation.getKing().equals(player.getUniqueId())) {
                 player.sendMessage("§c국왕만 국가 이름을 변경할 수 있습니다.");
@@ -374,7 +384,12 @@ public class NationCommand implements TabExecutor {
             return true;
         }
 
-        if (args[0].equalsIgnoreCase("invite") && args.length >= 2) {
+        if (args[0].equalsIgnoreCase("invite")) {
+            if (args.length < 2) {
+                player.sendMessage("§c사용법: /nation invite <플레이어>");
+                return true;
+            }
+            
             Nation nation = NationManager.getByPlayer(player.getUniqueId());
             if (nation == null || !nation.getKing().equals(player.getUniqueId())) {
                 player.sendMessage("§c초대는 국왕만 가능합니다.");
@@ -613,7 +628,11 @@ public class NationCommand implements TabExecutor {
             return true;
         }
 
-        if (args[0].equalsIgnoreCase("create") && args.length >= 2) {
+        if (args[0].equalsIgnoreCase("create")) {
+            if (args.length < 2) {
+                player.sendMessage("§c사용법: /nation create <이름>");
+                return true;
+            }
             String name = args[1];
 
             if (NationManager.isPlayerInNation(player.getUniqueId())) {
@@ -644,6 +663,8 @@ public class NationCommand implements TabExecutor {
             });
             return true;
         }
+
+        player.sendMessage("§c알 수 없는 하위 명령어입니다. /nation 을 입력해 도움말을 확인하세요.");
         return true;
     }
 

--- a/continent/src/main/java/me/continent/command/UnionCommand.java
+++ b/continent/src/main/java/me/continent/command/UnionCommand.java
@@ -223,9 +223,11 @@ public class UnionCommand implements TabExecutor {
                 }
                 return true;
             }
+            default -> {
+                player.sendMessage("§c알 수 없는 하위 명령어입니다.");
+                return true;
+            }
         }
-
-        return true;
     }
 
     @Override

--- a/continent/src/main/java/me/continent/war/WarCommand.java
+++ b/continent/src/main/java/me/continent/war/WarCommand.java
@@ -25,7 +25,12 @@ public class WarCommand implements TabExecutor {
             return true;
         }
 
-        if (args[0].equalsIgnoreCase("declare") && args.length >= 2) {
+        if (args[0].equalsIgnoreCase("declare")) {
+            if (args.length < 2) {
+                player.sendMessage("§c사용법: /war declare <국가명>");
+                return true;
+            }
+            
             Nation attacker = NationManager.getByPlayer(player.getUniqueId());
             if (attacker == null) {
                 player.sendMessage("§c소속된 국가이 없습니다.");
@@ -97,7 +102,9 @@ public class WarCommand implements TabExecutor {
             return true;
         }
 
+        player.sendMessage("§c알 수 없는 하위 명령어입니다. /war 를 입력해 도움말을 확인하세요.");
         return true;
+
     }
 
     @Override


### PR DESCRIPTION
## Summary
- show usage text for `/war declare` when args missing
- add unknown subcommand message for `/war`
- add unknown subcommand message for `/union`
- add usage text for `/nation create`, `/nation invite`, `/nation rename`, `/nation kick`
- add unknown subcommand message for `/nation`

## Testing
- `./gradlew build`

------
https://chatgpt.com/codex/tasks/task_e_6882210c86a8832490bb8292994ed07d