### PR TITLE
Add logistics status GUI and corporate filter

### DIFF
--- a/continent/src/main/java/me/continent/ContinentPlugin.java
+++ b/continent/src/main/java/me/continent/ContinentPlugin.java
@@ -107,6 +107,7 @@ public class ContinentPlugin extends JavaPlugin {
         getServer().getPluginManager().registerEvents(new ServerMenuListener(), this);
         getServer().getPluginManager().registerEvents(new me.continent.economy.gui.GoldMenuListener(), this);
         getServer().getPluginManager().registerEvents(new me.continent.enterprise.gui.EnterpriseMenuListener(), this);
+        getServer().getPluginManager().registerEvents(new me.continent.enterprise.gui.DeliveryMenuListener(), this);
         getServer().getPluginManager().registerEvents(new JobMenuListener(), this);
 
 

--- a/continent/src/main/java/me/continent/command/MarketCommand.java
+++ b/continent/src/main/java/me/continent/command/MarketCommand.java
@@ -14,7 +14,7 @@ public class MarketCommand implements CommandExecutor {
             sender.sendMessage("플레이어만 사용할 수 있습니다.");
             return true;
         }
-        MarketGUI.open(player, 1, MarketManager.SortMode.NEWEST, false);
+        MarketGUI.open(player, 1, MarketManager.SortMode.NEWEST, MarketManager.FilterMode.ALL, false);
         return true;
     }
 }

--- a/continent/src/main/java/me/continent/enterprise/gui/DeliveryMenuListener.java
+++ b/continent/src/main/java/me/continent/enterprise/gui/DeliveryMenuListener.java
@@ -1,0 +1,19 @@
+package me.continent.enterprise.gui;
+
+import org.bukkit.entity.Player;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+import org.bukkit.event.inventory.InventoryClickEvent;
+import org.bukkit.inventory.Inventory;
+
+/** Handles clicks in the delivery status GUI. */
+public class DeliveryMenuListener implements Listener {
+    @EventHandler
+    public void onClick(InventoryClickEvent event) {
+        Inventory inv = event.getInventory();
+        if (inv.getHolder() instanceof DeliveryStatusGUI.Holder) {
+            event.setCancelled(true);
+            // In future, could open detailed logs.
+        }
+    }
+}

--- a/continent/src/main/java/me/continent/enterprise/gui/DeliveryStatusGUI.java
+++ b/continent/src/main/java/me/continent/enterprise/gui/DeliveryStatusGUI.java
@@ -1,0 +1,74 @@
+package me.continent.enterprise.gui;
+
+import me.continent.enterprise.Enterprise;
+import me.continent.enterprise.logistics.DeliveryEntry;
+import me.continent.enterprise.logistics.DeliveryState;
+import me.continent.enterprise.logistics.LogisticsManager;
+import org.bukkit.Bukkit;
+import org.bukkit.Material;
+import org.bukkit.entity.Player;
+import org.bukkit.inventory.Inventory;
+import org.bukkit.inventory.InventoryHolder;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.inventory.meta.ItemMeta;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/** GUI showing current delivery status for an enterprise. */
+public class DeliveryStatusGUI {
+    public static void open(Player player, Enterprise enterprise) {
+        Holder holder = new Holder(enterprise);
+        Inventory inv = Bukkit.createInventory(holder, 27, "배송 상태");
+        holder.setInventory(inv);
+        fill(inv);
+        List<DeliveryEntry> list = LogisticsManager.getShipments(enterprise.getId());
+        int idx = 0;
+        for (DeliveryEntry e : list) {
+            if (idx >= 27) break;
+            ItemStack item = e.getItem().clone();
+            ItemMeta meta = item.getItemMeta();
+            meta.setDisplayName(item.getItemMeta().getDisplayName());
+            List<String> lore = new ArrayList<>();
+            lore.add("§7대상: " + e.getTarget());
+            lore.add("§7수량: " + e.getAmount());
+            lore.add("§7상태: " + stateName(e.getState()));
+            long remain = e.getFinishTime() - System.currentTimeMillis();
+            if (remain < 0) remain = 0;
+            lore.add("§7남은 시간: " + (remain / 1000) + "s");
+            lore.add("§7보상: " + e.getReward() + "G");
+            meta.setLore(lore);
+            item.setItemMeta(meta);
+            inv.setItem(idx++, item);
+        }
+        player.openInventory(inv);
+    }
+
+    private static String stateName(DeliveryState st) {
+        return switch (st) {
+            case WAITING -> "대기 중";
+            case MOVING -> "이동 중";
+            case HALTED -> "중단됨";
+            case COMPLETED -> "완료됨";
+        };
+    }
+
+    private static void fill(Inventory inv) {
+        ItemStack pane = new ItemStack(Material.GRAY_STAINED_GLASS_PANE);
+        ItemMeta meta = pane.getItemMeta();
+        meta.setDisplayName(" ");
+        pane.setItemMeta(meta);
+        for (int i = 0; i < inv.getSize(); i++) {
+            inv.setItem(i, pane);
+        }
+    }
+
+    static class Holder implements InventoryHolder {
+        private final Enterprise ent;
+        private Inventory inv;
+        Holder(Enterprise ent) { this.ent = ent; }
+        void setInventory(Inventory inv) { this.inv = inv; }
+        @Override public Inventory getInventory() { return inv; }
+        public Enterprise getEnterprise() { return ent; }
+    }
+}

--- a/continent/src/main/java/me/continent/enterprise/gui/EnterpriseMenuListener.java
+++ b/continent/src/main/java/me/continent/enterprise/gui/EnterpriseMenuListener.java
@@ -1,6 +1,7 @@
 package me.continent.enterprise.gui;
 
 import me.continent.enterprise.EnterpriseType;
+import me.continent.enterprise.gui.DeliveryStatusGUI;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
@@ -36,8 +37,11 @@ public class EnterpriseMenuListener implements Listener {
         } else if (inv.getHolder() instanceof EnterpriseMenuService.MainHolder holder) {
             event.setCancelled(true);
             Player player = (Player) event.getWhoClicked();
-            if (event.getRawSlot() == 49) {
+            int slot = event.getRawSlot();
+            if (slot == 49) {
                 player.closeInventory();
+            } else if (slot == 13) {
+                DeliveryStatusGUI.open(player, holder.getEnterprise());
             } else {
                 player.sendMessage("§e준비 중인 기능입니다.");
             }

--- a/continent/src/main/java/me/continent/enterprise/gui/EnterpriseMenuService.java
+++ b/continent/src/main/java/me/continent/enterprise/gui/EnterpriseMenuService.java
@@ -153,6 +153,7 @@ public class EnterpriseMenuService {
         holder.setInventory(inv);
         fill(inv);
         inv.setItem(10, button(Material.NAME_TAG, "기업 정보", null));
+        inv.setItem(13, button(Material.CHEST_MINECART, "배송 상태 확인", null));
         inv.setItem(49, button(Material.BARRIER, "닫기", null));
         player.openInventory(inv);
     }

--- a/continent/src/main/java/me/continent/enterprise/logistics/DeliveryEntry.java
+++ b/continent/src/main/java/me/continent/enterprise/logistics/DeliveryEntry.java
@@ -1,0 +1,35 @@
+package me.continent.enterprise.logistics;
+
+import org.bukkit.inventory.ItemStack;
+
+import java.util.UUID;
+
+/** Information about an ongoing delivery. */
+public class DeliveryEntry {
+    private final UUID id;
+    private final ItemStack item;
+    private final String target;
+    private final int amount;
+    private DeliveryState state;
+    private final long finishTime;
+    private final int reward;
+
+    public DeliveryEntry(UUID id, ItemStack item, String target, int amount, DeliveryState state, long finishTime, int reward) {
+        this.id = id;
+        this.item = item;
+        this.target = target;
+        this.amount = amount;
+        this.state = state;
+        this.finishTime = finishTime;
+        this.reward = reward;
+    }
+
+    public UUID getId() { return id; }
+    public ItemStack getItem() { return item; }
+    public String getTarget() { return target; }
+    public int getAmount() { return amount; }
+    public DeliveryState getState() { return state; }
+    public void setState(DeliveryState state) { this.state = state; }
+    public long getFinishTime() { return finishTime; }
+    public int getReward() { return reward; }
+}

--- a/continent/src/main/java/me/continent/enterprise/logistics/DeliveryState.java
+++ b/continent/src/main/java/me/continent/enterprise/logistics/DeliveryState.java
@@ -1,0 +1,9 @@
+package me.continent.enterprise.logistics;
+
+/** States of a delivery in progress. */
+public enum DeliveryState {
+    WAITING,
+    MOVING,
+    HALTED,
+    COMPLETED
+}

--- a/continent/src/main/java/me/continent/enterprise/logistics/LogisticsManager.java
+++ b/continent/src/main/java/me/continent/enterprise/logistics/LogisticsManager.java
@@ -1,0 +1,16 @@
+package me.continent.enterprise.logistics;
+
+import java.util.*;
+
+/** Simple manager for delivery entries. */
+public class LogisticsManager {
+    private static final Map<String, List<DeliveryEntry>> byEnterprise = new HashMap<>();
+
+    public static void addShipment(String enterpriseId, DeliveryEntry entry) {
+        byEnterprise.computeIfAbsent(enterpriseId, k -> new ArrayList<>()).add(entry);
+    }
+
+    public static List<DeliveryEntry> getShipments(String enterpriseId) {
+        return new ArrayList<>(byEnterprise.getOrDefault(enterpriseId, Collections.emptyList()));
+    }
+}

--- a/continent/src/main/java/me/continent/market/MarketItem.java
+++ b/continent/src/main/java/me/continent/market/MarketItem.java
@@ -12,6 +12,8 @@ public class MarketItem {
     private int pricePerUnit;
     private int stock;
     private LocalDateTime listedAt;
+    /** Enterprise ID if this item is listed by an enterprise, otherwise null. */
+    private String enterpriseId;
 
     public MarketItem(UUID id, UUID seller, ItemStack item, int pricePerUnit, int stock, LocalDateTime listedAt) {
         this.id = id;
@@ -20,6 +22,12 @@ public class MarketItem {
         this.pricePerUnit = pricePerUnit;
         this.stock = stock;
         this.listedAt = listedAt;
+        this.enterpriseId = null;
+    }
+
+    public MarketItem(UUID id, UUID seller, String enterpriseId, ItemStack item, int pricePerUnit, int stock, LocalDateTime listedAt) {
+        this(id, seller, item, pricePerUnit, stock, listedAt);
+        this.enterpriseId = enterpriseId;
     }
 
     public UUID getId() {
@@ -52,5 +60,13 @@ public class MarketItem {
 
     public LocalDateTime getListedAt() {
         return listedAt;
+    }
+
+    public String getEnterpriseId() {
+        return enterpriseId;
+    }
+
+    public void setEnterpriseId(String enterpriseId) {
+        this.enterpriseId = enterpriseId;
     }
 }

--- a/continent/src/main/java/me/continent/market/MarketRegisterGUI.java
+++ b/continent/src/main/java/me/continent/market/MarketRegisterGUI.java
@@ -15,7 +15,11 @@ import java.util.UUID;
 
 public class MarketRegisterGUI {
     public static void open(Player player) {
-        Holder holder = new Holder(player.getUniqueId());
+        open(player, null);
+    }
+
+    public static void open(Player player, String enterpriseId) {
+        Holder holder = new Holder(player.getUniqueId(), enterpriseId);
         Inventory inv = Bukkit.createInventory(holder, 45, "상품 등록");
         holder.setInventory(inv);
         fill(inv);
@@ -79,12 +83,14 @@ public class MarketRegisterGUI {
 
     static class Holder implements InventoryHolder {
         private final UUID owner;
+        private final String enterpriseId;
         private int price = 1;
         private Inventory inv;
-        Holder(UUID owner) { this.owner = owner; }
+        Holder(UUID owner, String enterpriseId) { this.owner = owner; this.enterpriseId = enterpriseId; }
         void setInventory(Inventory inv) { this.inv = inv; }
         @Override public Inventory getInventory() { return inv; }
         public UUID getOwner() { return owner; }
+        public String getEnterpriseId() { return enterpriseId; }
         public int getPrice() { return price; }
         public void setPrice(int price) { this.price = Math.max(1, price); }
     }

--- a/continent/src/main/java/me/continent/menu/ServerMenuListener.java
+++ b/continent/src/main/java/me/continent/menu/ServerMenuListener.java
@@ -38,7 +38,7 @@ public class ServerMenuListener implements Listener {
                     player.sendMessage("§f골드: §e" + String.format("%.2f", gold) + "G");
                     player.sendMessage("§f국가: §e" + nationName);
                 }
-                case 37 -> MarketGUI.open(player, 1, MarketManager.SortMode.NEWEST, false);
+                case 37 -> MarketGUI.open(player, 1, MarketManager.SortMode.NEWEST, MarketManager.FilterMode.ALL, false);
                 case 16 -> me.continent.economy.gui.GoldMenuService.openMenu(player);
                 case 40 -> player.sendMessage("§e준비 중인 기능입니다.");
                 case 43 -> me.continent.job.JobMenuService.openSelect(player);


### PR DESCRIPTION
## Summary
- implement `DeliveryStatusGUI` with basic logistics status display
- add placeholders for logistics data management
- integrate delivery status button in enterprise menu
- extend `MarketManager` with corporate filter modes
- allow registering market items under an enterprise
- add filter toggle and new info lines in market GUI

## Testing
- `./gradlew build -x test`

------
https://chatgpt.com/codex/tasks/task_e_68824891dbcc8324a9b58fd1d645bf39