### PR TITLE
Add nation and enterprise listing menus

### DIFF
--- a/continent/src/main/java/me/continent/ContinentPlugin.java
+++ b/continent/src/main/java/me/continent/ContinentPlugin.java
@@ -29,6 +29,8 @@ import me.continent.job.JobManager;
 import me.continent.job.JobMenuListener;
 import me.continent.command.JobCommand;
 import me.continent.enterprise.EnterpriseTypeConfig;
+import me.continent.nation.gui.NationListListener;
+import me.continent.enterprise.gui.EnterpriseListListener;
 import org.bukkit.plugin.java.JavaPlugin;
 import me.continent.player.PlayerDataManager;
 import me.continent.command.MarketCommand;
@@ -112,6 +114,8 @@ public class ContinentPlugin extends JavaPlugin {
         getServer().getPluginManager().registerEvents(new me.continent.economy.gui.GoldMenuListener(), this);
         getServer().getPluginManager().registerEvents(new me.continent.enterprise.gui.EnterpriseMenuListener(), this);
         getServer().getPluginManager().registerEvents(new me.continent.enterprise.gui.DeliveryMenuListener(), this);
+        getServer().getPluginManager().registerEvents(new me.continent.nation.gui.NationListListener(), this);
+        getServer().getPluginManager().registerEvents(new me.continent.enterprise.gui.EnterpriseListListener(), this);
         getServer().getPluginManager().registerEvents(new JobMenuListener(), this);
 
 

--- a/continent/src/main/java/me/continent/command/EnterpriseCommand.java
+++ b/continent/src/main/java/me/continent/command/EnterpriseCommand.java
@@ -30,6 +30,28 @@ public class EnterpriseCommand implements CommandExecutor {
             return true;
         }
 
+        if (args[0].equalsIgnoreCase("list")) {
+            me.continent.enterprise.gui.EnterpriseListGUI.open(player);
+            return true;
+        }
+
+        if (args[0].equalsIgnoreCase("setsymbol")) {
+            if (!EnterpriseManager.hasEnterprise(player.getUniqueId())) {
+                player.sendMessage("§c보유한 기업이 없습니다.");
+                return true;
+            }
+            Enterprise ent = EnterpriseManager.getByOwner(player.getUniqueId()).iterator().next();
+            var item = player.getInventory().getItemInMainHand();
+            if (item == null || !item.getType().name().endsWith("BANNER")) {
+                player.sendMessage("§c손에 배너를 들고 있어야 합니다.");
+                return true;
+            }
+            ent.setSymbol(item.clone());
+            EnterpriseStorage.save(ent);
+            player.sendMessage("§a기업 상징이 업데이트되었습니다.");
+            return true;
+        }
+
         if (args[0].equalsIgnoreCase("register")) {
             if (args.length < 3) {
                 me.continent.enterprise.gui.EnterpriseMenuService.openRegister(player);

--- a/continent/src/main/java/me/continent/command/NationCommand.java
+++ b/continent/src/main/java/me/continent/command/NationCommand.java
@@ -420,14 +420,10 @@ public class NationCommand implements TabExecutor {
 
 
         if (args[0].equalsIgnoreCase("list")) {
-            Set<Nation> all = Set.copyOf(NationManager.getAll());
-            if (all.isEmpty()) {
+            if (NationManager.getAll().isEmpty()) {
                 player.sendMessage("§7등록된 국가가 없습니다.");
-                return true;
-            }
-            player.sendMessage("§6[서버 국가 목록]");
-            for (Nation k : all) {
-                player.sendMessage("§f- " + k.getName());
+            } else {
+                me.continent.nation.gui.NationListGUI.open(player);
             }
             return true;
         }

--- a/continent/src/main/java/me/continent/enterprise/Enterprise.java
+++ b/continent/src/main/java/me/continent/enterprise/Enterprise.java
@@ -9,6 +9,8 @@ public class Enterprise {
     private final EnterpriseType type;
     private final UUID owner;
     private final long registeredAt;
+    // Enterprise symbol item (banner)
+    private org.bukkit.inventory.ItemStack symbol;
 
     public Enterprise(String id, String name, EnterpriseType type, UUID owner, long registeredAt) {
         this.id = id;
@@ -16,6 +18,8 @@ public class Enterprise {
         this.type = type;
         this.owner = owner;
         this.registeredAt = registeredAt;
+        // default symbol is a white banner
+        this.symbol = new org.bukkit.inventory.ItemStack(org.bukkit.Material.WHITE_BANNER);
     }
 
     public String getId() {
@@ -40,5 +44,15 @@ public class Enterprise {
 
     public long getRegisteredAt() {
         return registeredAt;
+    }
+
+    public org.bukkit.inventory.ItemStack getSymbol() {
+        return symbol;
+    }
+
+    public void setSymbol(org.bukkit.inventory.ItemStack symbol) {
+        if (symbol != null && symbol.getType().name().endsWith("BANNER")) {
+            this.symbol = symbol;
+        }
     }
 }

--- a/continent/src/main/java/me/continent/enterprise/EnterpriseStorage.java
+++ b/continent/src/main/java/me/continent/enterprise/EnterpriseStorage.java
@@ -24,6 +24,7 @@ public class EnterpriseStorage {
         config.set("type", enterprise.getType().name());
         config.set("owner", enterprise.getOwner().toString());
         config.set("registeredAt", enterprise.getRegisteredAt());
+        config.set("symbol", me.continent.utils.ItemSerialization.serializeItem(enterprise.getSymbol()));
         try {
             config.save(file);
         } catch (IOException e) {
@@ -38,7 +39,10 @@ public class EnterpriseStorage {
         EnterpriseType type = EnterpriseType.valueOf(config.getString("type"));
         UUID owner = UUID.fromString(config.getString("owner"));
         long registeredAt = config.getLong("registeredAt", System.currentTimeMillis());
-        return new Enterprise(id, name, type, owner, registeredAt);
+        Enterprise ent = new Enterprise(id, name, type, owner, registeredAt);
+        org.bukkit.inventory.ItemStack symbol = me.continent.utils.ItemSerialization.deserializeItem(config.getString("symbol"));
+        if (symbol != null) ent.setSymbol(symbol);
+        return ent;
     }
 
     public static void loadAll() {

--- a/continent/src/main/java/me/continent/enterprise/gui/EnterpriseListGUI.java
+++ b/continent/src/main/java/me/continent/enterprise/gui/EnterpriseListGUI.java
@@ -1,0 +1,39 @@
+package me.continent.enterprise.gui;
+
+import me.continent.enterprise.Enterprise;
+import me.continent.enterprise.EnterpriseManager;
+import org.bukkit.Bukkit;
+import org.bukkit.Material;
+import org.bukkit.entity.Player;
+import org.bukkit.inventory.Inventory;
+import org.bukkit.inventory.InventoryHolder;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.inventory.meta.ItemMeta;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class EnterpriseListGUI {
+    public static void open(Player player) {
+        List<Enterprise> list = new ArrayList<>(EnterpriseManager.getAll());
+        int size = Math.min(54, Math.max(9, ((list.size() - 1) / 9 + 1) * 9));
+        Holder holder = new Holder();
+        Inventory inv = Bukkit.createInventory(holder, size, "기업 목록");
+        holder.inv = inv;
+        for (int i = 0; i < list.size() && i < size; i++) {
+            Enterprise e = list.get(i);
+            ItemStack item = e.getSymbol() == null ? new ItemStack(Material.WHITE_BANNER) : e.getSymbol().clone();
+            ItemMeta meta = item.getItemMeta();
+            meta.setDisplayName(e.getName());
+            item.setItemMeta(meta);
+            inv.setItem(i, item);
+        }
+        player.openInventory(inv);
+    }
+
+    static class Holder implements InventoryHolder {
+        private Inventory inv;
+        @Override
+        public Inventory getInventory() { return inv; }
+    }
+}

--- a/continent/src/main/java/me/continent/enterprise/gui/EnterpriseListListener.java
+++ b/continent/src/main/java/me/continent/enterprise/gui/EnterpriseListListener.java
@@ -1,0 +1,16 @@
+package me.continent.enterprise.gui;
+
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+import org.bukkit.event.inventory.InventoryClickEvent;
+import org.bukkit.inventory.Inventory;
+
+public class EnterpriseListListener implements Listener {
+    @EventHandler
+    public void onClick(InventoryClickEvent event) {
+        Inventory inv = event.getInventory();
+        if (inv.getHolder() instanceof EnterpriseListGUI.Holder) {
+            event.setCancelled(true);
+        }
+    }
+}

--- a/continent/src/main/java/me/continent/enterprise/gui/EnterpriseMenuListener.java
+++ b/continent/src/main/java/me/continent/enterprise/gui/EnterpriseMenuListener.java
@@ -2,6 +2,7 @@ package me.continent.enterprise.gui;
 
 import me.continent.enterprise.EnterpriseType;
 import me.continent.enterprise.gui.DeliveryStatusGUI;
+import me.continent.enterprise.gui.EnterpriseListGUI;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
@@ -42,6 +43,17 @@ public class EnterpriseMenuListener implements Listener {
                 player.closeInventory();
             } else if (slot == 13) {
                 DeliveryStatusGUI.open(player, holder.getEnterprise());
+            } else if (slot == 16) {
+                EnterpriseListGUI.open(player);
+            } else if (slot == 19) {
+                var item = player.getInventory().getItemInMainHand();
+                if (item != null && item.getType().name().endsWith("BANNER")) {
+                    holder.getEnterprise().setSymbol(item.clone());
+                    me.continent.enterprise.EnterpriseStorage.save(holder.getEnterprise());
+                    player.sendMessage("§a기업 상징이 업데이트되었습니다.");
+                } else {
+                    player.sendMessage("§c손에 배너를 들고 있어야 합니다.");
+                }
             } else {
                 player.sendMessage("§e준비 중인 기능입니다.");
             }

--- a/continent/src/main/java/me/continent/enterprise/gui/EnterpriseMenuService.java
+++ b/continent/src/main/java/me/continent/enterprise/gui/EnterpriseMenuService.java
@@ -154,6 +154,8 @@ public class EnterpriseMenuService {
         fill(inv);
         inv.setItem(10, button(Material.NAME_TAG, "기업 정보", null));
         inv.setItem(13, button(Material.CHEST_MINECART, "배송 상태 확인", null));
+        inv.setItem(16, button(Material.FILLED_MAP, "기업 목록", null));
+        inv.setItem(19, button(Material.WHITE_BANNER, "상징 설정", null));
         inv.setItem(49, button(Material.BARRIER, "닫기", null));
         player.openInventory(inv);
     }

--- a/continent/src/main/java/me/continent/nation/gui/NationListGUI.java
+++ b/continent/src/main/java/me/continent/nation/gui/NationListGUI.java
@@ -1,0 +1,39 @@
+package me.continent.nation.gui;
+
+import me.continent.nation.Nation;
+import me.continent.nation.NationManager;
+import org.bukkit.Bukkit;
+import org.bukkit.Material;
+import org.bukkit.entity.Player;
+import org.bukkit.inventory.Inventory;
+import org.bukkit.inventory.InventoryHolder;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.inventory.meta.ItemMeta;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class NationListGUI {
+    public static void open(Player player) {
+        List<Nation> list = new ArrayList<>(NationManager.getAll());
+        int size = Math.min(54, Math.max(9, ((list.size() - 1) / 9 + 1) * 9));
+        Holder holder = new Holder();
+        Inventory inv = Bukkit.createInventory(holder, size, "국가 목록");
+        holder.inv = inv;
+        for (int i = 0; i < list.size() && i < size; i++) {
+            Nation n = list.get(i);
+            ItemStack item = n.getSymbol() == null ? new ItemStack(Material.WHITE_BANNER) : n.getSymbol().clone();
+            ItemMeta meta = item.getItemMeta();
+            meta.setDisplayName(n.getName());
+            item.setItemMeta(meta);
+            inv.setItem(i, item);
+        }
+        player.openInventory(inv);
+    }
+
+    static class Holder implements InventoryHolder {
+        private Inventory inv;
+        @Override
+        public Inventory getInventory() { return inv; }
+    }
+}

--- a/continent/src/main/java/me/continent/nation/gui/NationListListener.java
+++ b/continent/src/main/java/me/continent/nation/gui/NationListListener.java
@@ -1,0 +1,16 @@
+package me.continent.nation.gui;
+
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+import org.bukkit.event.inventory.InventoryClickEvent;
+import org.bukkit.inventory.Inventory;
+
+public class NationListListener implements Listener {
+    @EventHandler
+    public void onClick(InventoryClickEvent event) {
+        Inventory inv = event.getInventory();
+        if (inv.getHolder() instanceof NationListGUI.Holder) {
+            event.setCancelled(true);
+        }
+    }
+}

--- a/continent/src/main/java/me/continent/nation/service/NationMenuListener.java
+++ b/continent/src/main/java/me/continent/nation/service/NationMenuListener.java
@@ -17,7 +17,9 @@ public class NationMenuListener implements Listener {
             Player player = (Player) event.getWhoClicked();
             Nation nation = holder.getNation();
             int slot = event.getRawSlot();
-            if (slot == 19) {
+            if (slot == 11) {
+                me.continent.nation.gui.NationListGUI.open(player);
+            } else if (slot == 19) {
                 NationMemberService.openMenu(player, nation);
             } else if (slot == 21) {
                 NationTreasuryService.openMenu(player, nation);

--- a/continent/src/main/java/me/continent/nation/service/NationMenuService.java
+++ b/continent/src/main/java/me/continent/nation/service/NationMenuService.java
@@ -32,6 +32,8 @@ public class NationMenuService {
         symbol.setItemMeta(meta);
         inv.setItem(13, symbol);
 
+        inv.setItem(11, createItem(Material.FILLED_MAP, "국가 목록"));
+
         inv.setItem(19, createItem(Material.PLAYER_HEAD, "구성원"));
         inv.setItem(21, createItem(Material.GOLD_INGOT, "금고 관리"));
         inv.setItem(23, createItem(Material.COMPASS, "국가 스폰 이동"));


### PR DESCRIPTION
## Summary
- track an enterprise banner symbol
- let players set or view enterprise symbols via `/enterprise setsymbol` or the enterprise menu
- open a list of all nations or enterprises with their symbols
- register new GUI listeners

## Testing
- `./gradlew build`

------
https://chatgpt.com/codex/tasks/task_e_688250b57504832497c4b4e773a91370