### PR TITLE
Add upkeep and treasury GUIs

### DIFF
--- a/continent/src/main/java/me/continent/ContinentPlugin.java
+++ b/continent/src/main/java/me/continent/ContinentPlugin.java
@@ -24,6 +24,7 @@ import me.continent.nation.service.MaintenanceService;
 import me.continent.nation.service.NationMenuListener;
 import me.continent.nation.service.NationTreasuryListener;
 import me.continent.nation.service.NationMemberListener;
+import me.continent.nation.service.NationUpkeepListener;
 import me.continent.menu.ServerMenuListener;
 import me.continent.job.JobManager;
 import me.continent.job.JobMenuListener;
@@ -110,6 +111,7 @@ public class ContinentPlugin extends JavaPlugin {
         getServer().getPluginManager().registerEvents(new NationMenuListener(), this);
         getServer().getPluginManager().registerEvents(new NationTreasuryListener(), this);
         getServer().getPluginManager().registerEvents(new NationMemberListener(), this);
+        getServer().getPluginManager().registerEvents(new NationUpkeepListener(), this);
         getServer().getPluginManager().registerEvents(new ServerMenuListener(), this);
         getServer().getPluginManager().registerEvents(new me.continent.economy.gui.GoldMenuListener(), this);
         getServer().getPluginManager().registerEvents(new me.continent.enterprise.gui.EnterpriseMenuListener(), this);

--- a/continent/src/main/java/me/continent/nation/service/NationMenuListener.java
+++ b/continent/src/main/java/me/continent/nation/service/NationMenuListener.java
@@ -7,6 +7,7 @@ import org.bukkit.event.Listener;
 import org.bukkit.event.inventory.InventoryClickEvent;
 import org.bukkit.inventory.Inventory;
 import me.continent.menu.ServerMenuService;
+import me.continent.nation.service.NationUpkeepService;
 
 public class NationMenuListener implements Listener {
     @EventHandler
@@ -23,6 +24,8 @@ public class NationMenuListener implements Listener {
                 NationMemberService.openMenu(player, nation);
             } else if (slot == 21) {
                 NationTreasuryService.openMenu(player, nation);
+            } else if (slot == 29) {
+                NationUpkeepService.openMenu(player, nation);
             } else if (slot == 23) {
                 var spawn = nation.getSpawnLocation();
                 if (spawn != null) {

--- a/continent/src/main/java/me/continent/nation/service/NationMenuService.java
+++ b/continent/src/main/java/me/continent/nation/service/NationMenuService.java
@@ -36,6 +36,7 @@ public class NationMenuService {
 
         inv.setItem(19, createItem(Material.PLAYER_HEAD, "구성원"));
         inv.setItem(21, createItem(Material.GOLD_INGOT, "금고 관리"));
+        inv.setItem(29, createItem(Material.PAPER, "세금 정보"));
         inv.setItem(23, createItem(Material.COMPASS, "국가 스폰 이동"));
         inv.setItem(25, createItem(Material.CHEST, "국가 창고"));
         inv.setItem(31, createItem(Material.ARROW, "메인 메뉴"));

--- a/continent/src/main/java/me/continent/nation/service/NationTreasuryListener.java
+++ b/continent/src/main/java/me/continent/nation/service/NationTreasuryListener.java
@@ -18,14 +18,24 @@ public class NationTreasuryListener implements Listener {
             Nation nation = holder.getNation();
             int slot = event.getRawSlot();
             if (slot == 11) {
-                NationTreasuryService.promptDeposit(player, nation);
-                player.closeInventory();
+                NationTreasuryService.openAmount(player, nation, NationTreasuryService.Mode.DEPOSIT, 1);
             } else if (slot == 15) {
-                NationTreasuryService.promptWithdraw(player, nation);
-                player.closeInventory();
+                NationTreasuryService.openAmount(player, nation, NationTreasuryService.Mode.WITHDRAW, 1);
             } else if (slot == 22) {
                 ServerMenuService.openMenu(player);
             }
+        } else if (inv.getHolder() instanceof NationTreasuryService.AmountHolder holder) {
+            event.setCancelled(true);
+            Player player = (Player) event.getWhoClicked();
+            int slot = event.getRawSlot();
+            if (slot == 20) { holder.setAmount(holder.getAmount() - 10); NationTreasuryService.renderAmount(inv, holder, player); }
+            else if (slot == 21) { holder.setAmount(holder.getAmount() - 1); NationTreasuryService.renderAmount(inv, holder, player); }
+            else if (slot == 23) { holder.setAmount(holder.getAmount() + 1); NationTreasuryService.renderAmount(inv, holder, player); }
+            else if (slot == 24) { holder.setAmount(holder.getAmount() + 10); NationTreasuryService.renderAmount(inv, holder, player); }
+            else if (slot == 41) { holder.setAmount(NationTreasuryService.getMaxAmount(player, holder)); NationTreasuryService.renderAmount(inv, holder, player); }
+            else if (slot == 38) { player.closeInventory(); }
+            else if (slot == 40) { NationTreasuryService.perform(player, holder); player.closeInventory(); }
+            else if (slot == 42) { NationTreasuryService.openMenu(player, holder.getNation()); }
         }
     }
 }

--- a/continent/src/main/java/me/continent/nation/service/NationUpkeepListener.java
+++ b/continent/src/main/java/me/continent/nation/service/NationUpkeepListener.java
@@ -1,0 +1,23 @@
+package me.continent.nation.service;
+
+import me.continent.nation.Nation;
+import org.bukkit.entity.Player;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+import org.bukkit.event.inventory.InventoryClickEvent;
+import org.bukkit.inventory.Inventory;
+
+public class NationUpkeepListener implements Listener {
+    @EventHandler
+    public void onClick(InventoryClickEvent event) {
+        Inventory inv = event.getInventory();
+        if (inv.getHolder() instanceof NationUpkeepService.UpkeepHolder holder) {
+            event.setCancelled(true);
+            Player player = (Player) event.getWhoClicked();
+            Nation nation = holder.getNation();
+            if (event.getRawSlot() == 22) {
+                NationMenuService.openMenu(player, nation);
+            }
+        }
+    }
+}

--- a/continent/src/main/java/me/continent/nation/service/NationUpkeepService.java
+++ b/continent/src/main/java/me/continent/nation/service/NationUpkeepService.java
@@ -1,0 +1,63 @@
+package me.continent.nation.service;
+
+import me.continent.nation.Nation;
+import org.bukkit.Bukkit;
+import org.bukkit.Material;
+import org.bukkit.entity.Player;
+import org.bukkit.inventory.Inventory;
+import org.bukkit.inventory.InventoryHolder;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.inventory.meta.ItemMeta;
+
+import java.time.Instant;
+import java.time.ZoneId;
+import java.time.format.DateTimeFormatter;
+import java.util.List;
+
+public class NationUpkeepService {
+    public static void openMenu(Player player, Nation nation) {
+        UpkeepHolder holder = new UpkeepHolder(nation);
+        Inventory inv = Bukkit.createInventory(holder, 27, "Nation Upkeep");
+        holder.setInventory(inv);
+        render(inv, nation);
+        player.openInventory(inv);
+    }
+
+    static void render(Inventory inv, Nation nation) {
+        inv.clear();
+        ItemStack cost = item(Material.PAPER, "이번 주 유지비");
+        ItemMeta cMeta = cost.getItemMeta();
+        double amount = MaintenanceService.getWeeklyCost(nation);
+        cMeta.setLore(List.of("§7금액: " + amount + "G", "§7미납 주: " + nation.getUnpaidWeeks()));
+        cost.setItemMeta(cMeta);
+        inv.setItem(11, cost);
+
+        ItemStack last = item(Material.CLOCK, "마지막 납부");
+        ItemMeta lMeta = last.getItemMeta();
+        String date = nation.getLastMaintenance() == 0 ? "없음" :
+                DateTimeFormatter.ofPattern("yyyy/MM/dd").withZone(ZoneId.systemDefault())
+                        .format(Instant.ofEpochMilli(nation.getLastMaintenance()));
+        lMeta.setLore(List.of("§7일자: " + date));
+        last.setItemMeta(lMeta);
+        inv.setItem(15, last);
+
+        inv.setItem(22, item(Material.ARROW, "뒤로"));
+    }
+
+    private static ItemStack item(Material mat, String name) {
+        ItemStack is = new ItemStack(mat);
+        ItemMeta meta = is.getItemMeta();
+        meta.setDisplayName(name);
+        is.setItemMeta(meta);
+        return is;
+    }
+
+    static class UpkeepHolder implements InventoryHolder {
+        private final Nation nation;
+        private Inventory inv;
+        UpkeepHolder(Nation n) { this.nation = n; }
+        void setInventory(Inventory inv) { this.inv = inv; }
+        @Override public Inventory getInventory() { return inv; }
+        public Nation getNation() { return nation; }
+    }
+}


### PR DESCRIPTION
## Summary
- add GUI for nation upkeep status
- extend nation treasury to use GUI-based deposit/withdraw amounts
- hook new menus into nation menu
- register new listeners

## Testing
- `./gradlew test`

------
https://chatgpt.com/codex/tasks/task_e_68825361c344832482073371fcd2169a