### PR TITLE
Add basic enterprise production system

### DIFF
--- a/continent/src/main/java/me/continent/ContinentPlugin.java
+++ b/continent/src/main/java/me/continent/ContinentPlugin.java
@@ -85,6 +85,8 @@ public class ContinentPlugin extends JavaPlugin {
         SpecialtyManager.load(this);
         JobManager.load(this);
         EnterpriseTypeConfig.load(this);
+        me.continent.enterprise.production.ProductionManager.load(this);
+        me.continent.enterprise.production.ProductionManager.schedule();
 
         CropGrowthManager.init(this);
 
@@ -118,6 +120,7 @@ public class ContinentPlugin extends JavaPlugin {
         getServer().getPluginManager().registerEvents(new me.continent.enterprise.gui.DeliveryMenuListener(), this);
         getServer().getPluginManager().registerEvents(new me.continent.nation.gui.NationListListener(), this);
         getServer().getPluginManager().registerEvents(new me.continent.enterprise.gui.EnterpriseListListener(), this);
+        getServer().getPluginManager().registerEvents(new me.continent.enterprise.gui.ProductionMenuListener(), this);
         getServer().getPluginManager().registerEvents(new JobMenuListener(), this);
 
 

--- a/continent/src/main/java/me/continent/enterprise/gui/EnterpriseMenuListener.java
+++ b/continent/src/main/java/me/continent/enterprise/gui/EnterpriseMenuListener.java
@@ -3,6 +3,7 @@ package me.continent.enterprise.gui;
 import me.continent.enterprise.EnterpriseType;
 import me.continent.enterprise.gui.DeliveryStatusGUI;
 import me.continent.enterprise.gui.EnterpriseListGUI;
+import me.continent.enterprise.gui.ProductionMenuService;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
@@ -54,6 +55,8 @@ public class EnterpriseMenuListener implements Listener {
                 } else {
                     player.sendMessage("§c손에 배너를 들고 있어야 합니다.");
                 }
+            } else if (slot == 22) {
+                ProductionMenuService.open(player, holder.getEnterprise());
             } else {
                 player.sendMessage("§e준비 중인 기능입니다.");
             }

--- a/continent/src/main/java/me/continent/enterprise/gui/EnterpriseMenuService.java
+++ b/continent/src/main/java/me/continent/enterprise/gui/EnterpriseMenuService.java
@@ -156,6 +156,7 @@ public class EnterpriseMenuService {
         inv.setItem(13, button(Material.CHEST_MINECART, "배송 상태 확인", null));
         inv.setItem(16, button(Material.FILLED_MAP, "기업 목록", null));
         inv.setItem(19, button(Material.WHITE_BANNER, "상징 설정", null));
+        inv.setItem(22, button(Material.CRAFTING_TABLE, "생산 관리", null));
         inv.setItem(49, button(Material.BARRIER, "닫기", null));
         player.openInventory(inv);
     }

--- a/continent/src/main/java/me/continent/enterprise/gui/ProductionMenuListener.java
+++ b/continent/src/main/java/me/continent/enterprise/gui/ProductionMenuListener.java
@@ -1,0 +1,41 @@
+package me.continent.enterprise.gui;
+
+import me.continent.enterprise.Enterprise;
+import me.continent.enterprise.production.*;
+import org.bukkit.entity.Player;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+import org.bukkit.event.inventory.InventoryClickEvent;
+
+/** Listener for production menu interactions. */
+public class ProductionMenuListener implements Listener {
+    @EventHandler
+    public void onClick(InventoryClickEvent event) {
+        if (!(event.getWhoClicked() instanceof Player player)) return;
+        if (!(event.getInventory().getHolder() instanceof ProductionMenuService.Holder holder)) return;
+        event.setCancelled(true);
+        int slot = event.getRawSlot();
+        Enterprise ent = holder.getEnterprise();
+        ProductionJob job = ProductionManager.getJob(ent.getId());
+        if (slot == 26) {
+            me.continent.enterprise.gui.EnterpriseMenuService.openMain(player, ent);
+            return;
+        }
+        if (job != null) {
+            if (slot == 13 && job.isComplete()) {
+                if (ProductionManager.collect(player, ent.getId())) {
+                    player.sendMessage("§a제품이 창고에 보관되었습니다.");
+                }
+                ProductionMenuService.open(player, ent);
+            }
+            return;
+        }
+        var list = ProductionManager.getRecipes(ent.getType());
+        if (slot >= 0 && slot < list.size()) {
+            ProductionRecipe recipe = list.get(slot);
+            boolean ok = ProductionManager.startJob(player, ent.getId(), recipe);
+            if (!ok) player.sendMessage("§c자원이 부족하거나 슬롯이 가득 찼습니다.");
+            ProductionMenuService.open(player, ent);
+        }
+    }
+}

--- a/continent/src/main/java/me/continent/enterprise/gui/ProductionMenuService.java
+++ b/continent/src/main/java/me/continent/enterprise/gui/ProductionMenuService.java
@@ -1,0 +1,92 @@
+package me.continent.enterprise.gui;
+
+import me.continent.enterprise.Enterprise;
+import me.continent.enterprise.EnterpriseManager;
+import me.continent.enterprise.production.*;
+import org.bukkit.Bukkit;
+import org.bukkit.Material;
+import org.bukkit.entity.Player;
+import org.bukkit.inventory.Inventory;
+import org.bukkit.inventory.InventoryHolder;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.inventory.meta.ItemMeta;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+/** GUI service for enterprise production. */
+public class ProductionMenuService {
+    public static class Holder implements InventoryHolder {
+        private final Enterprise enterprise;
+        private Inventory inv;
+        Holder(Enterprise ent) { this.enterprise = ent; }
+        void setInventory(Inventory inv) { this.inv = inv; }
+        @Override public Inventory getInventory() { return inv; }
+        public Enterprise getEnterprise() { return enterprise; }
+    }
+
+    public static void open(Player player, Enterprise enterprise) {
+        Holder holder = new Holder(enterprise);
+        Inventory inv = Bukkit.createInventory(holder, 27, "생산 관리");
+        holder.setInventory(inv);
+        render(inv, enterprise);
+        player.openInventory(inv);
+    }
+
+    private static void render(Inventory inv, Enterprise enterprise) {
+        fill(inv);
+        ProductionJob job = ProductionManager.getJob(enterprise.getId());
+        if (job != null) {
+            ItemStack item = job.getRecipe().getOutput();
+            item.setAmount(job.getRecipe().getAmount());
+            ItemMeta meta = item.getItemMeta();
+            meta.setDisplayName("§a진행 중: " + job.getRecipe().getName());
+            List<String> lore = new ArrayList<>();
+            long remain = job.getFinishTime() - System.currentTimeMillis();
+            if (remain < 0) remain = 0;
+            lore.add("남은 시간: " + (remain / 1000) + "s");
+            if (job.isComplete()) lore.set(0, "완료됨 - 수령 대기");
+            meta.setLore(lore);
+            item.setItemMeta(meta);
+            inv.setItem(13, item);
+        } else {
+            int idx = 0;
+            for (ProductionRecipe r : ProductionManager.getRecipes(enterprise.getType())) {
+                ItemStack item = r.getOutput();
+                item.setAmount(r.getAmount());
+                ItemMeta meta = item.getItemMeta();
+                meta.setDisplayName(r.getName());
+                List<String> lore = new ArrayList<>();
+                for (Map.Entry<Material,Integer> e : r.getResources().entrySet()) {
+                    lore.add(e.getKey().name()+" x"+e.getValue());
+                }
+                lore.add("시간: "+r.getTime()+"s");
+                meta.setLore(lore);
+                item.setItemMeta(meta);
+                inv.setItem(idx++, item);
+                if (idx >= 26) break;
+            }
+        }
+        inv.setItem(26, button(Material.ARROW, "뒤로", null));
+    }
+
+    private static ItemStack button(Material m, String name, List<String> lore) {
+        ItemStack item = new ItemStack(m);
+        ItemMeta meta = item.getItemMeta();
+        meta.setDisplayName(name);
+        if (lore != null) meta.setLore(lore);
+        item.setItemMeta(meta);
+        return item;
+    }
+
+    private static void fill(Inventory inv) {
+        ItemStack pane = new ItemStack(Material.GRAY_STAINED_GLASS_PANE);
+        ItemMeta meta = pane.getItemMeta();
+        meta.setDisplayName(" ");
+        pane.setItemMeta(meta);
+        for (int i = 0; i < inv.getSize(); i++) {
+            inv.setItem(i, pane);
+        }
+    }
+}

--- a/continent/src/main/java/me/continent/enterprise/production/ProductionJob.java
+++ b/continent/src/main/java/me/continent/enterprise/production/ProductionJob.java
@@ -1,0 +1,45 @@
+package me.continent.enterprise.production;
+
+/** Represents an active production job. */
+public class ProductionJob {
+    private final ProductionRecipe recipe;
+    private final String enterpriseId;
+    private final long startTime;
+    private final long finishTime;
+    private boolean collected;
+
+    public ProductionJob(String enterpriseId, ProductionRecipe recipe, long startTime) {
+        this.enterpriseId = enterpriseId;
+        this.recipe = recipe;
+        this.startTime = startTime;
+        this.finishTime = startTime + recipe.getTime() * 1000L;
+    }
+
+    public ProductionRecipe getRecipe() {
+        return recipe;
+    }
+
+    public String getEnterpriseId() {
+        return enterpriseId;
+    }
+
+    public long getStartTime() {
+        return startTime;
+    }
+
+    public long getFinishTime() {
+        return finishTime;
+    }
+
+    public boolean isComplete() {
+        return System.currentTimeMillis() >= finishTime;
+    }
+
+    public boolean isCollected() {
+        return collected;
+    }
+
+    public void setCollected() {
+        this.collected = true;
+    }
+}

--- a/continent/src/main/java/me/continent/enterprise/production/ProductionManager.java
+++ b/continent/src/main/java/me/continent/enterprise/production/ProductionManager.java
@@ -1,0 +1,99 @@
+package me.continent.enterprise.production;
+
+import me.continent.ContinentPlugin;
+import me.continent.enterprise.EnterpriseType;
+import org.bukkit.Bukkit;
+import org.bukkit.Material;
+import org.bukkit.configuration.file.FileConfiguration;
+import org.bukkit.configuration.file.YamlConfiguration;
+import org.bukkit.entity.Player;
+import org.bukkit.inventory.ItemStack;
+
+import java.io.File;
+import java.util.*;
+
+/** Handles production recipes and active jobs. */
+public class ProductionManager {
+    private static final Map<EnterpriseType, List<ProductionRecipe>> recipes = new EnumMap<>(EnterpriseType.class);
+    private static final Map<String, ProductionJob> activeJobs = new HashMap<>();
+
+    public static void load(ContinentPlugin plugin) {
+        recipes.clear();
+        File file = new File(plugin.getDataFolder(), "enterprise_products.yml");
+        if (!file.exists()) plugin.saveResource("enterprise_products.yml", false);
+        FileConfiguration config = YamlConfiguration.loadConfiguration(file);
+        for (EnterpriseType type : EnterpriseType.values()) {
+            String path = type.name();
+            if (!config.contains(path)) continue;
+            var section = config.getConfigurationSection(path);
+            if (section == null) continue;
+            List<ProductionRecipe> list = new ArrayList<>();
+            for (String id : section.getKeys(false)) {
+                var cs = section.getConfigurationSection(id);
+                if (cs == null) continue;
+                String name = cs.getString("name", id);
+                String mat = cs.getString("output", "STONE");
+                ItemStack out = new ItemStack(Material.matchMaterial(mat));
+                int time = cs.getInt("time", 10);
+                int amount = cs.getInt("amount", 1);
+                Map<Material, Integer> res = new HashMap<>();
+                var rs = cs.getConfigurationSection("resources");
+                if (rs != null)
+                    for (String k : rs.getKeys(false))
+                        res.put(Material.matchMaterial(k), rs.getInt(k));
+                list.add(new ProductionRecipe(id, name, type, out, res, time, amount));
+            }
+            recipes.put(type, list);
+        }
+    }
+
+    public static List<ProductionRecipe> getRecipes(EnterpriseType type) {
+        return recipes.getOrDefault(type, Collections.emptyList());
+    }
+
+    /** Return active job for enterprise or null. */
+    public static ProductionJob getJob(String enterpriseId) {
+        return activeJobs.get(enterpriseId);
+    }
+
+    /** Attempt to start production for player enterprise. */
+    public static boolean startJob(Player player, String enterpriseId, ProductionRecipe recipe) {
+        if (activeJobs.containsKey(enterpriseId)) return false; // slot busy
+        // check resources in player inventory
+        for (var e : recipe.getResources().entrySet()) {
+            if (!player.getInventory().containsAtLeast(new ItemStack(e.getKey()), e.getValue())) {
+                return false;
+            }
+        }
+        // remove resources
+        for (var e : recipe.getResources().entrySet()) {
+            player.getInventory().removeItem(new ItemStack(e.getKey(), e.getValue()));
+        }
+        ProductionJob job = new ProductionJob(enterpriseId, recipe, System.currentTimeMillis());
+        activeJobs.put(enterpriseId, job);
+        return true;
+    }
+
+    /** Collect completed production. */
+    public static boolean collect(Player player, String enterpriseId) {
+        ProductionJob job = activeJobs.get(enterpriseId);
+        if (job == null || !job.isComplete() || job.isCollected()) return false;
+        ItemStack out = job.getRecipe().getOutput();
+        out.setAmount(job.getRecipe().getAmount());
+        player.getInventory().addItem(out);
+        job.setCollected();
+        activeJobs.remove(enterpriseId);
+        return true;
+    }
+
+    /** Schedule periodic checks to notify players. */
+    public static void schedule() {
+        Bukkit.getScheduler().runTaskTimer(ContinentPlugin.getInstance(), () -> {
+            for (ProductionJob job : activeJobs.values()) {
+                if (job.isComplete() && !job.isCollected()) {
+                    // simply keep job until player collects
+                }
+            }
+        }, 20L, 20L);
+    }
+}

--- a/continent/src/main/java/me/continent/enterprise/production/ProductionRecipe.java
+++ b/continent/src/main/java/me/continent/enterprise/production/ProductionRecipe.java
@@ -1,0 +1,57 @@
+package me.continent.enterprise.production;
+
+import me.continent.enterprise.EnterpriseType;
+import org.bukkit.Material;
+import org.bukkit.inventory.ItemStack;
+
+import java.util.Map;
+
+/** Recipe definition for enterprise production. */
+public class ProductionRecipe {
+    private final String id;
+    private final String name;
+    private final EnterpriseType type;
+    private final ItemStack output;
+    private final Map<Material, Integer> resources;
+    private final int time; // seconds
+    private final int amount;
+
+    public ProductionRecipe(String id, String name, EnterpriseType type, ItemStack output,
+                            Map<Material, Integer> resources, int time, int amount) {
+        this.id = id;
+        this.name = name;
+        this.type = type;
+        this.output = output;
+        this.resources = resources;
+        this.time = time;
+        this.amount = amount;
+    }
+
+    public String getId() {
+        return id;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public EnterpriseType getType() {
+        return type;
+    }
+
+    public ItemStack getOutput() {
+        return output.clone();
+    }
+
+    public Map<Material, Integer> getResources() {
+        return resources;
+    }
+
+    public int getTime() {
+        return time;
+    }
+
+    public int getAmount() {
+        return amount;
+    }
+}

--- a/continent/src/main/resources/enterprise_products.yml
+++ b/continent/src/main/resources/enterprise_products.yml
@@ -1,0 +1,16 @@
+MANUFACTURING:
+  iron_sword:
+    name: "철검"
+    output: IRON_SWORD
+    time: 30
+    amount: 1
+    resources:
+      IRON_INGOT: 2
+      STICK: 1
+  bread:
+    name: "빵"
+    output: BREAD
+    time: 10
+    amount: 3
+    resources:
+      WHEAT: 3


### PR DESCRIPTION
## Summary
- add `ProductionRecipe` model and `ProductionManager`
- implement production GUI and listener
- hook production into enterprise menu
- load recipes from new `enterprise_products.yml`
- register production manager and listener in plugin

## Testing
- `./gradlew test --no-daemon`

------
https://chatgpt.com/codex/tasks/task_e_68825dbe09a48324b58dacae1518577d