### PR TITLE
Refactor enterprise persistence

### DIFF
--- a/continent/src/main/java/me/continent/ContinentPlugin.java
+++ b/continent/src/main/java/me/continent/ContinentPlugin.java
@@ -37,7 +37,7 @@ import me.continent.player.PlayerDataManager;
 import me.continent.command.MarketCommand;
 import me.continent.market.MarketManager;
 import me.continent.market.MarketListener;
-import me.continent.enterprise.EnterpriseStorage;
+import me.continent.enterprise.EnterpriseService;
 import me.continent.enterprise.contract.ContractManager;
 import me.continent.storage.NationStorage;
 import me.continent.storage.UnionStorage;
@@ -93,7 +93,8 @@ public class ContinentPlugin extends JavaPlugin {
         ScoreboardService.schedule();
 
         MarketManager.load(this);
-        EnterpriseStorage.loadAll();
+        EnterpriseService.init(this);
+        EnterpriseService.loadAll();
         ContractManager.loadAll();
         ContractManager.scheduleGeneration();
         getServer().getPluginManager().registerEvents(new TerritoryListener(), this);
@@ -134,7 +135,7 @@ public class ContinentPlugin extends JavaPlugin {
         // 중앙은행 데이터 저장
         CentralBankDataManager.save();
         MarketManager.save();
-        EnterpriseStorage.saveAll();
+        EnterpriseService.saveAll();
         ContractManager.saveAll();
         PlayerDataManager.saveAll();
         UnionStorage.saveAll();

--- a/continent/src/main/java/me/continent/command/EnterpriseCommand.java
+++ b/continent/src/main/java/me/continent/command/EnterpriseCommand.java
@@ -47,7 +47,7 @@ public class EnterpriseCommand implements CommandExecutor {
                 return true;
             }
             ent.setSymbol(item.clone());
-            EnterpriseStorage.save(ent);
+            EnterpriseService.save(ent);
             player.sendMessage("§a기업 상징이 업데이트되었습니다.");
             return true;
         }
@@ -82,7 +82,7 @@ public class EnterpriseCommand implements CommandExecutor {
             String id = UUID.randomUUID().toString();
             Enterprise ent = new Enterprise(id, name, type, player.getUniqueId(), System.currentTimeMillis());
             EnterpriseManager.register(ent);
-            EnterpriseStorage.save(ent);
+            EnterpriseService.save(ent);
             player.sendMessage("§a기업이 설립되었습니다: " + name + "(" + type + ")");
             return true;
         }

--- a/continent/src/main/java/me/continent/enterprise/EnterpriseRepository.java
+++ b/continent/src/main/java/me/continent/enterprise/EnterpriseRepository.java
@@ -1,0 +1,11 @@
+package me.continent.enterprise;
+
+import java.io.File;
+
+/** Repository interface for enterprise persistence. */
+public interface EnterpriseRepository {
+    void save(Enterprise enterprise);
+    Enterprise load(File file);
+    void loadAll();
+    void saveAll();
+}

--- a/continent/src/main/java/me/continent/enterprise/EnterpriseService.java
+++ b/continent/src/main/java/me/continent/enterprise/EnterpriseService.java
@@ -1,0 +1,33 @@
+package me.continent.enterprise;
+
+import me.continent.ContinentPlugin;
+
+/** Central access point for enterprise persistence. */
+public class EnterpriseService {
+    private static EnterpriseRepository repository;
+
+    /** Initialize default repository. */
+    public static void init(ContinentPlugin plugin) {
+        repository = new YamlEnterpriseRepository(plugin);
+    }
+
+    public static void setRepository(EnterpriseRepository repo) {
+        repository = repo;
+    }
+
+    public static EnterpriseRepository getRepository() {
+        return repository;
+    }
+
+    public static void save(Enterprise enterprise) {
+        repository.save(enterprise);
+    }
+
+    public static void loadAll() {
+        repository.loadAll();
+    }
+
+    public static void saveAll() {
+        repository.saveAll();
+    }
+}

--- a/continent/src/main/java/me/continent/enterprise/gui/EnterpriseMenuListener.java
+++ b/continent/src/main/java/me/continent/enterprise/gui/EnterpriseMenuListener.java
@@ -50,7 +50,7 @@ public class EnterpriseMenuListener implements Listener {
                 var item = player.getInventory().getItemInMainHand();
                 if (item != null && item.getType().name().endsWith("BANNER")) {
                     holder.getEnterprise().setSymbol(item.clone());
-                    me.continent.enterprise.EnterpriseStorage.save(holder.getEnterprise());
+                    me.continent.enterprise.EnterpriseService.save(holder.getEnterprise());
                     player.sendMessage("§a기업 상징이 업데이트되었습니다.");
                 } else {
                     player.sendMessage("§c손에 배너를 들고 있어야 합니다.");

--- a/continent/src/main/java/me/continent/enterprise/gui/EnterpriseMenuService.java
+++ b/continent/src/main/java/me/continent/enterprise/gui/EnterpriseMenuService.java
@@ -140,7 +140,7 @@ public class EnterpriseMenuService {
         String id = UUID.randomUUID().toString();
         Enterprise ent = new Enterprise(id, holder.getName(), holder.getType(), player.getUniqueId(), System.currentTimeMillis());
         EnterpriseManager.register(ent);
-        EnterpriseStorage.save(ent);
+        EnterpriseService.save(ent);
         PlayerDataManager.save(player.getUniqueId());
         player.sendMessage("§a기업이 설립되었습니다: " + ent.getName());
         openMain(player, ent);


### PR DESCRIPTION
## Summary
- add `EnterpriseRepository` interface for enterprise persistence
- implement `YamlEnterpriseRepository` and `EnterpriseService`
- update plugin and commands to use the new service
- remove old `EnterpriseStorage` implementation

## Testing
- `./gradlew build`

------
https://chatgpt.com/codex/tasks/task_e_68827516564c832495a250ac12f4a674