### PR TITLE
Add slime core mechanic and proximity boss bar

### DIFF
--- a/continent/src/main/java/me/continent/war/CoreSlimeManager.java
+++ b/continent/src/main/java/me/continent/war/CoreSlimeManager.java
@@ -1,0 +1,61 @@
+package me.continent.war;
+
+import me.continent.nation.Nation;
+import me.continent.nation.NationManager;
+import org.bukkit.Location;
+import org.bukkit.World;
+import org.bukkit.entity.Slime;
+import org.bukkit.entity.EntityType;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Manages invisible slime entities used to track core damage during war.
+ */
+public class CoreSlimeManager {
+    private static final Map<String, Slime> slimes = new HashMap<>();
+
+    private static String key(War war, String nation) {
+        return war.hashCode() + ":" + nation.toLowerCase();
+    }
+
+    public static void createWar(War war) {
+        spawnSlime(war, war.getAttacker());
+        spawnSlime(war, war.getDefender());
+    }
+
+    private static void spawnSlime(War war, String nationName) {
+        String k = key(war, nationName);
+        if (slimes.containsKey(k)) return;
+        Nation nation = NationManager.getByName(nationName);
+        if (nation == null) return;
+        Location loc = nation.getCoreLocation();
+        if (loc == null) return;
+        World world = loc.getWorld();
+        if (world == null) return;
+        Slime slime = (Slime) world.spawnEntity(loc.clone().add(0.5, 1, 0.5), EntityType.SLIME);
+        slime.setAI(false);
+        slime.setInvisible(true);
+        slime.setCollidable(false);
+        slime.setGravity(false);
+        slime.setSize(1);
+        slime.setSilent(true);
+        slime.setPersistent(true);
+        slime.setRemoveWhenFarAway(false);
+        slime.addScoreboardTag("core_slime:" + nationName.toLowerCase());
+        slimes.put(k, slime);
+    }
+
+    public static void remove(War war, String nationName) {
+        Slime slime = slimes.remove(key(war, nationName));
+        if (slime != null && !slime.isDead()) {
+            slime.remove();
+        }
+    }
+
+    public static void endWar(War war) {
+        remove(war, war.getAttacker());
+        remove(war, war.getDefender());
+    }
+}

--- a/continent/src/main/java/me/continent/war/WarManager.java
+++ b/continent/src/main/java/me/continent/war/WarManager.java
@@ -4,6 +4,7 @@ import me.continent.nation.Nation;
 import me.continent.nation.NationManager;
 import me.continent.nation.service.CoreService;
 import me.continent.storage.NationStorage;
+import me.continent.war.CoreSlimeManager;
 import org.bukkit.Bukkit;
 import org.bukkit.Material;
 
@@ -21,6 +22,7 @@ public class WarManager {
         initCoreHp(war, attacker);
         initCoreHp(war, defender);
         WarBossBarManager.createWar(war);
+        CoreSlimeManager.createWar(war);
         return war;
     }
 
@@ -55,6 +57,7 @@ public class WarManager {
 
         war.getBannedPlayers().clear();
         WarBossBarManager.endWar(war);
+        CoreSlimeManager.endWar(war);
 
         String msg = "§e[전쟁] §f" + war.getAttacker() + " 국가과 "
                 + war.getDefender() + " 국가의 전쟁이 종료되었습니다.";
@@ -77,6 +80,7 @@ public class WarManager {
         if (war == null) return;
         war.addDestroyedNation(nation.getName(), attacker.getName());
         WarBossBarManager.remove(war, nation.getName());
+        CoreSlimeManager.remove(war, nation.getName());
         CoreService.removeCore(nation);
         Bukkit.broadcastMessage("§c[전쟁] §f" + nation.getName() + " 국가의 코어가 파괴되었습니다!");
         surrender(nation);


### PR DESCRIPTION
## Summary
- add `CoreSlimeManager` to spawn invisible slime entities over nation cores during war
- update `WarBossBarManager` to show enemy core HP when players approach cores
- modify `CoreAttackListener` to reduce core HP when the slime is damaged
- integrate slime lifecycle with `WarManager`

## Testing
- `./gradlew build -x test`

------
https://chatgpt.com/codex/tasks/task_e_68830e03c15c8324870755a567217667