### PR TITLE
Adjust war core slime visibility and HP

### DIFF
--- a/continent/src/main/java/me/continent/war/CoreSlimeManager.java
+++ b/continent/src/main/java/me/continent/war/CoreSlimeManager.java
@@ -36,10 +36,11 @@ public class CoreSlimeManager {
         if (world == null) return;
         Slime slime = (Slime) world.spawnEntity(loc.clone().add(0.5, 1, 0.5), EntityType.SLIME);
         slime.setAI(false);
-        slime.setInvisible(true);
+        slime.setInvisible(false);
+        slime.setGlowing(true);
         slime.setCollidable(false);
         slime.setGravity(false);
-        slime.setSize(1);
+        slime.setSize(4);
         slime.setSilent(true);
         slime.setPersistent(true);
         slime.setRemoveWhenFarAway(false);

--- a/continent/src/main/java/me/continent/war/WarManager.java
+++ b/continent/src/main/java/me/continent/war/WarManager.java
@@ -11,7 +11,7 @@ import org.bukkit.Material;
 import java.util.*;
 
 public class WarManager {
-    public static final int VILLAGE_CORE_HP = 20;
+    public static final int VILLAGE_CORE_HP = 100;
     private static final Map<String, War> wars = new HashMap<>();
 
     public static War declareWar(Nation attacker, Nation defender) {


### PR DESCRIPTION
## Summary
- make core slime visible with a glowing outline
- enlarge the core slime hitbox
- increase village core HP to 100

## Testing
- `./gradlew test --no-daemon`

------
https://chatgpt.com/codex/tasks/task_e_6883143f91388324be84ae13d7d240f9