### PR TITLE
Fix core attack in survival

### DIFF
--- a/continent/src/main/java/me/continent/ContinentPlugin.java
+++ b/continent/src/main/java/me/continent/ContinentPlugin.java
@@ -18,6 +18,7 @@ import me.continent.protection.TerritoryProtectionListener;
 import me.continent.protection.CoreProtectionListener;
 import me.continent.war.CoreAttackListener;
 import me.continent.war.WarDeathListener;
+import me.continent.war.CoreSlimeDamageListener;
 import me.continent.protection.ProtectionStateListener;
 import me.continent.nation.service.ChestListener;
 import me.continent.nation.service.MaintenanceService;
@@ -103,6 +104,7 @@ public class ContinentPlugin extends JavaPlugin {
         getServer().getPluginManager().registerEvents(new TerritoryProtectionListener(), this);
         getServer().getPluginManager().registerEvents(new CoreProtectionListener(), this);
         getServer().getPluginManager().registerEvents(new CoreAttackListener(), this);
+        getServer().getPluginManager().registerEvents(new CoreSlimeDamageListener(), this);
         getServer().getPluginManager().registerEvents(new ChestListener(), this);
         getServer().getPluginManager().registerEvents(new ProtectionStateListener(), this);
         getServer().getPluginManager().registerEvents(new WarDeathListener(), this);

--- a/continent/src/main/java/me/continent/war/CoreSlimeDamageListener.java
+++ b/continent/src/main/java/me/continent/war/CoreSlimeDamageListener.java
@@ -1,0 +1,32 @@
+package me.continent.war;
+
+import org.bukkit.entity.Player;
+import org.bukkit.entity.Slime;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+import org.bukkit.event.entity.EntityDamageByEntityEvent;
+import org.bukkit.event.entity.EntityDamageEvent;
+
+/**
+ * Prevents core slimes from dying to environmental damage.
+ */
+public class CoreSlimeDamageListener implements Listener {
+
+    private boolean isCoreSlime(Slime slime) {
+        return slime.getScoreboardTags().stream()
+                .anyMatch(t -> t.startsWith("core_slime:"));
+    }
+
+    @EventHandler
+    public void onDamage(EntityDamageEvent event) {
+        if (!(event.getEntity() instanceof Slime slime)) return;
+        if (!isCoreSlime(slime)) return;
+
+        // Allow player attacks to be processed elsewhere
+        if (event instanceof EntityDamageByEntityEvent byEntity
+                && byEntity.getDamager() instanceof Player) {
+            return;
+        }
+        event.setCancelled(true);
+    }
+}

--- a/continent/src/main/java/me/continent/war/CoreSlimeManager.java
+++ b/continent/src/main/java/me/continent/war/CoreSlimeManager.java
@@ -2,10 +2,12 @@ package me.continent.war;
 
 import me.continent.nation.Nation;
 import me.continent.nation.NationManager;
+import me.continent.ContinentPlugin;
 import org.bukkit.Location;
 import org.bukkit.World;
 import org.bukkit.entity.Slime;
 import org.bukkit.entity.EntityType;
+import org.bukkit.scheduler.BukkitTask;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -15,6 +17,7 @@ import java.util.Map;
  */
 public class CoreSlimeManager {
     private static final Map<String, Slime> slimes = new HashMap<>();
+    private static BukkitTask task;
 
     private static String key(War war, String nation) {
         return war.hashCode() + ":" + nation.toLowerCase();
@@ -23,6 +26,7 @@ public class CoreSlimeManager {
     public static void createWar(War war) {
         spawnSlime(war, war.getAttacker());
         spawnSlime(war, war.getDefender());
+        startTask();
     }
 
     private static void spawnSlime(War war, String nationName) {
@@ -45,7 +49,7 @@ public class CoreSlimeManager {
         slime.setSilent(true);
         slime.setPersistent(true);
         slime.setRemoveWhenFarAway(false);
-        slime.setInvulnerable(true);
+        slime.setInvulnerable(false);
         slime.addScoreboardTag("core_slime:" + nationName.toLowerCase());
         slimes.put(k, slime);
     }
@@ -55,10 +59,38 @@ public class CoreSlimeManager {
         if (slime != null && !slime.isDead()) {
             slime.remove();
         }
+        if (slimes.isEmpty()) stopTask();
     }
 
     public static void endWar(War war) {
         remove(war, war.getAttacker());
         remove(war, war.getDefender());
+        if (slimes.isEmpty()) stopTask();
+    }
+
+    private static void startTask() {
+        if (task != null) return;
+        task = org.bukkit.Bukkit.getScheduler().runTaskTimer(
+                ContinentPlugin.getInstance(),
+                CoreSlimeManager::tick, 20L, 20L);
+    }
+
+    private static void stopTask() {
+        if (task != null) {
+            task.cancel();
+            task = null;
+        }
+    }
+
+    private static void tick() {
+        slimes.forEach((k, slime) -> {
+            if (slime == null || slime.isDead()) return;
+            String nationName = k.substring(k.indexOf(":") + 1);
+            Nation nation = NationManager.getByName(nationName);
+            if (nation == null) return;
+            Location loc = nation.getCoreLocation();
+            if (loc == null) return;
+            slime.teleport(loc.clone().add(0, 1, 0));
+        });
     }
 }


### PR DESCRIPTION
## Summary
- allow players to attack the core slime in survival mode
- keep core slime centered and immune to environment damage

## Testing
- `./gradlew build`


------
https://chatgpt.com/codex/tasks/task_e_68831e2e10848324870cce518c3240c0