### PR TITLE
Fix core slime attacks to trigger weapon enchants

### DIFF
--- a/continent/src/main/java/me/continent/war/CoreAttackListener.java
+++ b/continent/src/main/java/me/continent/war/CoreAttackListener.java
@@ -80,7 +80,6 @@ public class CoreAttackListener implements Listener {
                 .filter(t -> t.startsWith("core_slime:"))
                 .findFirst().orElse(null);
         if (tag == null) return;
-        event.setCancelled(true);
         Nation nation = NationManager.getByName(tag.substring("core_slime:".length()));
         if (nation == null) return;
         if (!(event.getDamager() instanceof Player attacker)) return;
@@ -94,5 +93,7 @@ public class CoreAttackListener implements Listener {
         for (int i = 0; i < dmg; i++) {
             WarManager.damageCore(nation, attackerNation);
         }
+        // Allow enchantments to trigger while preventing actual damage
+        event.setDamage(0);
     }
 }


### PR DESCRIPTION
## Summary
- allow enchantments to activate when hitting the core slime
- prevent the slime from taking damage while still processing core damage

## Testing
- `./gradlew -p continent build`

------
https://chatgpt.com/codex/tasks/task_e_6883280183b48324a6de88b5ce9b2c0e