### PR TITLE
Add basic RPG stat system

### DIFF
--- a/continent/src/main/java/me/continent/ContinentPlugin.java
+++ b/continent/src/main/java/me/continent/ContinentPlugin.java
@@ -76,6 +76,7 @@ public class ContinentPlugin extends JavaPlugin {
         registerCommand("menu", new MenuCommand());
         registerCommand("enterprise", new EnterpriseCommand());
         registerCommand("job", new JobCommand());
+        registerCommand("stat", new me.continent.command.StatCommand());
 
         // 중앙은행 데이터 로딩
         CentralBankDataManager.load();
@@ -127,6 +128,7 @@ public class ContinentPlugin extends JavaPlugin {
         getServer().getPluginManager().registerEvents(new me.continent.enterprise.gui.EnterpriseListListener(), this);
         getServer().getPluginManager().registerEvents(new me.continent.enterprise.gui.ProductionMenuListener(), this);
         getServer().getPluginManager().registerEvents(new JobMenuListener(), this);
+        getServer().getPluginManager().registerEvents(new me.continent.listener.StatLevelListener(), this);
 
 
         getServer().getPluginManager().registerEvents(new MarketListener(), this);

--- a/continent/src/main/java/me/continent/command/StatCommand.java
+++ b/continent/src/main/java/me/continent/command/StatCommand.java
@@ -1,0 +1,78 @@
+package me.continent.command;
+
+import me.continent.player.PlayerData;
+import me.continent.player.PlayerDataManager;
+import me.continent.stat.PlayerStats;
+import me.continent.stat.StatType;
+import org.bukkit.command.Command;
+import org.bukkit.command.CommandSender;
+import org.bukkit.command.TabExecutor;
+import org.bukkit.entity.Player;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Locale;
+
+public class StatCommand implements TabExecutor {
+    @Override
+    public boolean onCommand(CommandSender sender, Command cmd, String label, String[] args) {
+        if (!(sender instanceof Player player)) {
+            sender.sendMessage("플레이어만 사용할 수 있습니다.");
+            return true;
+        }
+        PlayerData data = PlayerDataManager.get(player.getUniqueId());
+        PlayerStats stats = data.getStats();
+
+        if (args.length == 0) {
+            player.sendMessage("§6[Stat] 현재 스탯");
+            for (StatType type : StatType.values()) {
+                player.sendMessage("§e" + type.name() + ": §f" + stats.get(type));
+            }
+            player.sendMessage("남은 포인트: " + stats.getUnusedPoints());
+            return true;
+        }
+        if (args[0].equalsIgnoreCase("add") && args.length >= 2) {
+            if (stats.getUnusedPoints() <= 0) {
+                player.sendMessage("§c사용 가능한 포인트가 없습니다.");
+                return true;
+            }
+            try {
+                StatType type = StatType.valueOf(args[1].toUpperCase(Locale.ROOT));
+                int current = stats.get(type);
+                int limit = 10;
+                if (stats.getMastery() == type) limit = 15;
+                if (current >= limit) {
+                    player.sendMessage("§c이미 최대 수치입니다.");
+                    return true;
+                }
+                if (current + 1 > 10 && stats.getMastery() == null) {
+                    stats.setMastery(type);
+                } else if (current + 1 > 10 && stats.getMastery() != type) {
+                    player.sendMessage("§c이미 다른 스탯의 마스터리를 해금했습니다.");
+                    return true;
+                }
+                stats.set(type, current + 1);
+                stats.usePoint();
+                PlayerDataManager.save(player.getUniqueId());
+                player.sendMessage("§a" + type.name() + " +1 (" + stats.get(type) + ")");
+            } catch (IllegalArgumentException e) {
+                player.sendMessage("§c잘못된 스탯입니다.");
+            }
+            return true;
+        }
+        return false;
+    }
+
+    @Override
+    public List<String> onTabComplete(CommandSender sender, Command cmd, String label, String[] args) {
+        if (args.length == 1) {
+            return List.of("add");
+        }
+        if (args.length == 2 && args[0].equalsIgnoreCase("add")) {
+            List<String> list = new ArrayList<>();
+            for (StatType type : StatType.values()) list.add(type.name().toLowerCase(Locale.ROOT));
+            return list;
+        }
+        return List.of();
+    }
+}

--- a/continent/src/main/java/me/continent/listener/StatLevelListener.java
+++ b/continent/src/main/java/me/continent/listener/StatLevelListener.java
@@ -1,0 +1,13 @@
+package me.continent.listener;
+
+import me.continent.stat.StatsManager;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+import org.bukkit.event.player.PlayerLevelChangeEvent;
+
+public class StatLevelListener implements Listener {
+    @EventHandler
+    public void onLevel(PlayerLevelChangeEvent event) {
+        StatsManager.checkLevelUp(event.getPlayer());
+    }
+}

--- a/continent/src/main/java/me/continent/player/PlayerData.java
+++ b/continent/src/main/java/me/continent/player/PlayerData.java
@@ -1,6 +1,7 @@
 package me.continent.player;
 
 import me.continent.nation.Nation;
+import me.continent.stat.PlayerStats;
 
 import java.util.HashSet;
 import java.util.Set;
@@ -12,6 +13,7 @@ public class PlayerData {
 
     private double gold;
     private final Set<String> pendingInvites = new HashSet<>();  // ✅ 중복 제거됨
+    private final PlayerStats stats = new PlayerStats();
 
     private Nation nation;
 
@@ -35,6 +37,10 @@ public class PlayerData {
     private int knownMaintenance = 0;
 
     private String jobId = null;
+
+    public PlayerStats getStats() {
+        return stats;
+    }
 
 
     public boolean isNationChatEnabled() {

--- a/continent/src/main/java/me/continent/stat/PlayerStats.java
+++ b/continent/src/main/java/me/continent/stat/PlayerStats.java
@@ -1,0 +1,57 @@
+package me.continent.stat;
+
+import java.util.EnumMap;
+import java.util.Map;
+
+public class PlayerStats {
+    private final Map<StatType, Integer> stats = new EnumMap<>(StatType.class);
+    private StatType mastery = null;
+    private int unusedPoints = 0;
+    private int lastLevelGiven = 0;
+
+    public PlayerStats() {
+        for (StatType type : StatType.values()) {
+            stats.put(type, 0);
+        }
+    }
+
+    public int get(StatType type) {
+        return stats.getOrDefault(type, 0);
+    }
+
+    public void set(StatType type, int value) {
+        stats.put(type, value);
+    }
+
+    public Map<StatType, Integer> getAll() {
+        return stats;
+    }
+
+    public StatType getMastery() {
+        return mastery;
+    }
+
+    public void setMastery(StatType mastery) {
+        this.mastery = mastery;
+    }
+
+    public int getUnusedPoints() {
+        return unusedPoints;
+    }
+
+    public void addPoints(int amount) {
+        this.unusedPoints += amount;
+    }
+
+    public void usePoint() {
+        if (unusedPoints > 0) unusedPoints--;
+    }
+
+    public int getLastLevelGiven() {
+        return lastLevelGiven;
+    }
+
+    public void setLastLevelGiven(int lvl) {
+        this.lastLevelGiven = lvl;
+    }
+}

--- a/continent/src/main/java/me/continent/stat/StatType.java
+++ b/continent/src/main/java/me/continent/stat/StatType.java
@@ -1,0 +1,9 @@
+package me.continent.stat;
+
+public enum StatType {
+    STRENGTH,
+    AGILITY,
+    INTELLIGENCE,
+    VITALITY,
+    LUCK
+}

--- a/continent/src/main/java/me/continent/stat/StatsManager.java
+++ b/continent/src/main/java/me/continent/stat/StatsManager.java
@@ -1,0 +1,64 @@
+package me.continent.stat;
+
+import me.continent.ContinentPlugin;
+import me.continent.player.PlayerData;
+import me.continent.player.PlayerDataManager;
+import org.bukkit.Bukkit;
+import org.bukkit.FireworkEffect;
+import org.bukkit.Sound;
+import org.bukkit.entity.EntityType;
+import org.bukkit.entity.Firework;
+import org.bukkit.entity.Player;
+import org.bukkit.inventory.meta.FireworkMeta;
+import org.bukkit.scheduler.BukkitRunnable;
+import org.bukkit.Color;
+
+public class StatsManager {
+
+    public static void checkLevelUp(Player player) {
+        PlayerData data = PlayerDataManager.get(player.getUniqueId());
+        PlayerStats stats = data.getStats();
+        int level = player.getLevel();
+        int last = stats.getLastLevelGiven();
+        if (level < 100) return;
+        int next = ((level - 100) / 25) * 25 + 100;
+        if (level < next || next <= last) return;
+        stats.setLastLevelGiven(next);
+        stats.addPoints(1);
+        PlayerDataManager.save(player.getUniqueId());
+        if (next % 100 == 0) {
+            launchFireworks(player, true);
+            player.sendTitle("§6★ 마스터 레벨 도달 ★", "§e스탯 포인트 +1!", 10, 40, 10);
+            player.playSound(player.getLocation(), Sound.ENTITY_PLAYER_LEVELUP, 1f, 1f);
+            player.playSound(player.getLocation(), Sound.UI_TOAST_CHALLENGE_COMPLETE, 1f, 1f);
+        } else {
+            launchFireworks(player, false);
+            player.sendActionBar("§e[Stat] §e스탯 포인트 +1!");
+        }
+    }
+
+    private static void launchFireworks(Player player, boolean multiple) {
+        if (multiple) {
+            new BukkitRunnable() {
+                int count = 0;
+                @Override
+                public void run() {
+                    spawnFirework(player, Color.fromRGB(0xFFDB4D));
+                    count++;
+                    if (count >= 5) cancel();
+                }
+            }.runTaskTimer(ContinentPlugin.getInstance(), 0L, 4L);
+        } else {
+            spawnFirework(player, Color.fromRGB(0xFFDB4D));
+        }
+    }
+
+    private static void spawnFirework(Player player, Color color) {
+        Firework fw = (Firework) player.getWorld().spawnEntity(player.getLocation(), EntityType.FIREWORK_ROCKET);
+        FireworkMeta meta = fw.getFireworkMeta();
+        meta.addEffect(FireworkEffect.builder().withColor(color).with(FireworkEffect.Type.STAR).build());
+        meta.setPower(0);
+        fw.setFireworkMeta(meta);
+        fw.detonate();
+    }
+}

--- a/continent/src/main/java/me/continent/storage/PlayerStorage.java
+++ b/continent/src/main/java/me/continent/storage/PlayerStorage.java
@@ -2,6 +2,8 @@ package me.continent.storage;
 
 import me.continent.ContinentPlugin;
 import me.continent.player.PlayerData;
+import me.continent.stat.PlayerStats;
+import me.continent.stat.StatType;
 import org.bukkit.configuration.file.FileConfiguration;
 import org.bukkit.configuration.file.YamlConfiguration;
 
@@ -27,6 +29,15 @@ public class PlayerStorage {
         config.set("maintenance", data.getKnownMaintenance());
         config.set("kingdomChat", data.isKingdomChatEnabled());
         config.set("job", data.getJobId());
+        PlayerStats stats = data.getStats();
+        for (StatType type : StatType.values()) {
+            config.set("stats." + type.name().toLowerCase(), stats.get(type));
+        }
+        if (stats.getMastery() != null) {
+            config.set("stats.mastery", stats.getMastery().name());
+        }
+        config.set("stats.points", stats.getUnusedPoints());
+        config.set("stats.lastLevel", stats.getLastLevelGiven());
 
         try {
             config.save(file);
@@ -46,6 +57,20 @@ public class PlayerStorage {
         data.setKnownMaintenance(config.getInt("maintenance", 0));
         data.setKingdomChatEnabled(config.getBoolean("kingdomChat", false));
         data.setJobId(config.getString("job", null));
+
+        PlayerStats stats = data.getStats();
+        for (StatType type : StatType.values()) {
+            int val = config.getInt("stats." + type.name().toLowerCase(), 0);
+            stats.set(type, val);
+        }
+        String mastery = config.getString("stats.mastery", null);
+        if (mastery != null) {
+            try {
+                stats.setMastery(StatType.valueOf(mastery));
+            } catch (IllegalArgumentException ignored) {}
+        }
+        stats.addPoints(config.getInt("stats.points", 0));
+        stats.setLastLevelGiven(config.getInt("stats.lastLevel", 0));
         return data;
     }
 }

--- a/continent/src/main/resources/plugin.yml
+++ b/continent/src/main/resources/plugin.yml
@@ -41,3 +41,6 @@ commands:
   job:
     description: Manage player jobs
     usage: /job <subcommand>
+  stat:
+    description: Player stat management
+    usage: /stat <add>


### PR DESCRIPTION
## Summary
- implement `StatType` enum and `PlayerStats` for storing player stats
- persist stats in `PlayerStorage`
- command `/stat` to allocate stat points
- award stat points at level milestones with fireworks via `StatsManager`
- register new command and listener in `ContinentPlugin`
- expose `PlayerStats` in `PlayerData`
- update `plugin.yml`

## Testing
- `./gradlew build`

------
https://chatgpt.com/codex/tasks/task_e_6887b7eb57e88324ac0d9cc4ae75f32f