### PR TITLE
Implement stat attribute effects

### DIFF
--- a/continent/src/main/java/me/continent/ContinentPlugin.java
+++ b/continent/src/main/java/me/continent/ContinentPlugin.java
@@ -129,6 +129,8 @@ public class ContinentPlugin extends JavaPlugin {
         getServer().getPluginManager().registerEvents(new me.continent.enterprise.gui.ProductionMenuListener(), this);
         getServer().getPluginManager().registerEvents(new JobMenuListener(), this);
         getServer().getPluginManager().registerEvents(new me.continent.listener.StatLevelListener(), this);
+        getServer().getPluginManager().registerEvents(new me.continent.listener.StatJoinListener(), this);
+        getServer().getPluginManager().registerEvents(new me.continent.listener.DoubleJumpListener(), this);
 
 
         getServer().getPluginManager().registerEvents(new MarketListener(), this);

--- a/continent/src/main/java/me/continent/command/StatCommand.java
+++ b/continent/src/main/java/me/continent/command/StatCommand.java
@@ -4,6 +4,7 @@ import me.continent.player.PlayerData;
 import me.continent.player.PlayerDataManager;
 import me.continent.stat.PlayerStats;
 import me.continent.stat.StatType;
+import me.continent.stat.StatsEffectManager;
 import org.bukkit.command.Command;
 import org.bukkit.command.CommandSender;
 import org.bukkit.command.TabExecutor;
@@ -54,6 +55,7 @@ public class StatCommand implements TabExecutor {
                 stats.set(type, current + 1);
                 stats.usePoint();
                 PlayerDataManager.save(player.getUniqueId());
+                StatsEffectManager.apply(player);
                 player.sendMessage("§a" + type.name() + " +1 (" + stats.get(type) + ")");
             } catch (IllegalArgumentException e) {
                 player.sendMessage("§c잘못된 스탯입니다.");

--- a/continent/src/main/java/me/continent/listener/DoubleJumpListener.java
+++ b/continent/src/main/java/me/continent/listener/DoubleJumpListener.java
@@ -1,0 +1,40 @@
+package me.continent.listener;
+
+import me.continent.player.PlayerDataManager;
+import me.continent.stat.StatType;
+import org.bukkit.GameMode;
+import org.bukkit.entity.Player;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+import org.bukkit.event.player.PlayerMoveEvent;
+import org.bukkit.event.player.PlayerToggleFlightEvent;
+import org.bukkit.util.Vector;
+
+public class DoubleJumpListener implements Listener {
+    @EventHandler
+    public void onToggleFlight(PlayerToggleFlightEvent event) {
+        Player player = event.getPlayer();
+        GameMode gm = player.getGameMode();
+        if (gm != GameMode.SURVIVAL && gm != GameMode.ADVENTURE) {
+            return;
+        }
+        var data = PlayerDataManager.get(player.getUniqueId());
+        if (data.getStats().get(StatType.AGILITY) < 10) return;
+        event.setCancelled(true);
+        player.setAllowFlight(false);
+        Vector vec = player.getLocation().getDirection().multiply(0.5).setY(0.7);
+        player.setVelocity(vec);
+    }
+
+    @EventHandler
+    public void onLand(PlayerMoveEvent event) {
+        Player player = event.getPlayer();
+        if (!player.isOnGround()) return;
+        GameMode gm = player.getGameMode();
+        if (gm != GameMode.SURVIVAL && gm != GameMode.ADVENTURE) return;
+        var data = PlayerDataManager.get(player.getUniqueId());
+        if (data.getStats().get(StatType.AGILITY) >= 10) {
+            player.setAllowFlight(true);
+        }
+    }
+}

--- a/continent/src/main/java/me/continent/listener/StatJoinListener.java
+++ b/continent/src/main/java/me/continent/listener/StatJoinListener.java
@@ -1,0 +1,13 @@
+package me.continent.listener;
+
+import me.continent.stat.StatsEffectManager;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+import org.bukkit.event.player.PlayerJoinEvent;
+
+public class StatJoinListener implements Listener {
+    @EventHandler
+    public void onJoin(PlayerJoinEvent event) {
+        StatsEffectManager.apply(event.getPlayer());
+    }
+}

--- a/continent/src/main/java/me/continent/stat/StatsEffectManager.java
+++ b/continent/src/main/java/me/continent/stat/StatsEffectManager.java
@@ -1,0 +1,62 @@
+package me.continent.stat;
+
+import me.continent.player.PlayerData;
+import me.continent.player.PlayerDataManager;
+import org.bukkit.attribute.Attribute;
+import org.bukkit.attribute.AttributeInstance;
+import org.bukkit.entity.Player;
+
+public class StatsEffectManager {
+    public static void apply(Player player) {
+        PlayerData data = PlayerDataManager.get(player.getUniqueId());
+        PlayerStats stats = data.getStats();
+        applyStrength(player, stats.get(StatType.STRENGTH));
+        applyAgility(player, stats.get(StatType.AGILITY));
+        applyIntelligence(player, stats.get(StatType.INTELLIGENCE));
+        applyVitality(player, stats.get(StatType.VITALITY));
+    }
+
+    private static void applyStrength(Player player, int val) {
+        AttributeInstance dmg = player.getAttribute(Attribute.ATTACK_DAMAGE);
+        if (dmg != null) {
+            double base = dmg.getDefaultValue();
+            dmg.setBaseValue(base * (1 + 0.05 * val));
+        }
+        if (val >= 10) {
+            AttributeInstance spd = player.getAttribute(Attribute.ATTACK_SPEED);
+            if (spd != null) spd.setBaseValue(1024.0); // effectively no delay
+        }
+    }
+
+    private static void applyAgility(Player player, int val) {
+        AttributeInstance speed = player.getAttribute(Attribute.MOVEMENT_SPEED);
+        if (speed != null) {
+            double base = speed.getDefaultValue();
+            speed.setBaseValue(base * (1 + 0.05 * val));
+        }
+        var gm = player.getGameMode();
+        boolean survivalLike = gm == org.bukkit.GameMode.SURVIVAL || gm == org.bukkit.GameMode.ADVENTURE;
+        if (val >= 10 && survivalLike) {
+            player.setAllowFlight(true);
+        } else if (survivalLike) {
+            player.setAllowFlight(false);
+        }
+    }
+
+    private static void applyIntelligence(Player player, int val) {
+        AttributeInstance luck = player.getAttribute(Attribute.LUCK);
+        if (luck != null) {
+            luck.setBaseValue(0.05 * val);
+        }
+    }
+
+    private static void applyVitality(Player player, int val) {
+        AttributeInstance health = player.getAttribute(Attribute.MAX_HEALTH);
+        if (health != null) {
+            double base = health.getDefaultValue();
+            double newMax = base * (1 + 0.05 * val);
+            health.setBaseValue(newMax);
+            if (player.getHealth() > newMax) player.setHealth(newMax);
+        }
+    }
+}

--- a/continent/src/main/java/me/continent/stat/StatsManager.java
+++ b/continent/src/main/java/me/continent/stat/StatsManager.java
@@ -12,6 +12,7 @@ import org.bukkit.entity.Player;
 import org.bukkit.inventory.meta.FireworkMeta;
 import org.bukkit.scheduler.BukkitRunnable;
 import org.bukkit.Color;
+import java.util.Random;
 
 public class StatsManager {
 
@@ -37,24 +38,39 @@ public class StatsManager {
         }
     }
 
+    private static final Color[] MULTI_COLORS = new Color[] {
+            Color.fromRGB(0xFFD700),
+            Color.fromRGB(0xFFFF00),
+            Color.fromRGB(0x800080)
+    };
+    private static final Random RANDOM = new Random();
+
     private static void launchFireworks(Player player, boolean multiple) {
         if (multiple) {
+            int total = 3 + RANDOM.nextInt(3); // 3~5
             new BukkitRunnable() {
                 int count = 0;
                 @Override
                 public void run() {
-                    spawnFirework(player, Color.fromRGB(0xFFDB4D));
+                    Color color = MULTI_COLORS[RANDOM.nextInt(MULTI_COLORS.length)];
+                    spawnFirework(player, color, true);
                     count++;
-                    if (count >= 5) cancel();
+                    if (count >= total) cancel();
                 }
             }.runTaskTimer(ContinentPlugin.getInstance(), 0L, 4L);
         } else {
-            spawnFirework(player, Color.fromRGB(0xFFDB4D));
+            spawnFirework(player, Color.fromRGB(0xFFDB4D), false);
         }
     }
 
-    private static void spawnFirework(Player player, Color color) {
-        Firework fw = (Firework) player.getWorld().spawnEntity(player.getLocation(), EntityType.FIREWORK_ROCKET);
+    private static void spawnFirework(Player player, Color color, boolean around) {
+        var loc = player.getLocation().clone();
+        if (around) {
+            double dx = (RANDOM.nextDouble() - 0.5) * 4.0;
+            double dz = (RANDOM.nextDouble() - 0.5) * 4.0;
+            loc.add(dx, 0, dz);
+        }
+        Firework fw = (Firework) player.getWorld().spawnEntity(loc, EntityType.FIREWORK_ROCKET);
         FireworkMeta meta = fw.getFireworkMeta();
         meta.addEffect(FireworkEffect.builder().withColor(color).with(FireworkEffect.Type.STAR).build());
         meta.setPower(0);


### PR DESCRIPTION
## Summary
- add dynamic attribute manager
- register listener to apply stat effects on join
- update stat command to apply effects when investing
- improve milestone fireworks
- add double jump ability for Agility 10

## Testing
- `./gradlew classes`
- `./gradlew test`


------
https://chatgpt.com/codex/tasks/task_e_6888180c79588324a8a37a61e6738a18